### PR TITLE
ci: pre-commit + CI gate on poetry check --lock (#180)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,6 +99,27 @@ jobs:
           format: table
           skip-dirs: '**/node_modules,**/.venv,**/__pycache__,**/.next,**/.vercel,**/dist,**/build,**/.pytest_cache,**/.claude'
 
+  poetry-lock:
+    name: poetry check --lock (src/cofounder_agent)
+    runs-on: ubuntu-latest
+    # GH#180 defense-in-depth — the same check runs locally as a pre-commit
+    # hook (.pre-commit-config.yaml) AND in the test workflow on Gitea
+    # (.gitea/workflows/ci.yml). Mirroring it here protects the public
+    # GitHub mirror in case a contributor opens a PR without pre-commit
+    # installed and without going through Gitea CI first.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Verify poetry.lock matches pyproject.toml
+        run: |
+          cd src/cofounder_agent
+          poetry check --lock
+
   sbom:
     name: SBOM + grype scan
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,17 @@ repos:
         pass_filenames: false
         files: '^src/cofounder_agent/services/.*\.py$'
         stages: [pre-commit]
+
+      # GH#180 — block poetry.lock drift before it lands in a commit.
+      # Mirrors the `poetry check --lock` step in .gitea/workflows/ci.yml
+      # (and the new defense-in-depth job in .github/workflows/security.yml).
+      # Only fires when src/cofounder_agent/{pyproject.toml,poetry.lock} is
+      # in the staged changes — other Python projects in this repo
+      # (mcp-server/, src/cofounder_agent/poindexter/) use uv, not Poetry.
+      - id: poetry-check-lock
+        name: poetry check --lock (src/cofounder_agent)
+        entry: bash -c 'cd src/cofounder_agent && poetry check --lock'
+        language: system
+        pass_filenames: false
+        files: '^src/cofounder_agent/(pyproject\.toml|poetry\.lock)$'
+        stages: [pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in contributing. Poindexter is built by Glad Labs LLC a
 ## Development Workflow
 
 1. Create a branch from `main`: `git checkout -b feat/your-feature`
-2. Install the pre-commit hooks once per clone: `pip install pre-commit && pre-commit install` — this wires up `gitleaks` (secret scan) and a few formatting checks so commits are blocked before anything sensitive lands in history.
+2. Install the pre-commit hooks once per clone: `pip install pre-commit && pre-commit install` — this wires up `gitleaks` (secret scan) and a few formatting checks so commits are blocked before anything sensitive lands in history. It also runs `poetry check --lock` (against `src/cofounder_agent/`) automatically on any commit that touches `pyproject.toml` or `poetry.lock`, which prevents `poetry.lock` drift from landing.
 3. Turn on commit signing: `bash scripts/setup-git-signing.sh` — see [Signed commits](#signed-commits) below.
 4. Make your changes
 5. Run tests and ensure they pass: `python -m pytest tests/unit/ -q`
@@ -43,11 +43,12 @@ unsigned — treat the warning as a signal to run the setup script.
 
 ## CI security gates
 
-Every PR and every push to `main` runs three automated security gates (see `.github/workflows/security.yml` + `.gitea/workflows/security.yml`):
+Every PR and every push to `main` runs four automated gates (see `.github/workflows/security.yml` + `.gitea/workflows/security.yml`):
 
 - **gitleaks** — secret scan across the diff + full history, blocks on any finding
 - **Trivy** — filesystem CVE scan, fails the build on HIGH / CRITICAL fixed vulnerabilities
 - **syft + grype** — generates a CycloneDX SBOM, scans it for HIGH / CRITICAL CVEs, and uploads the SBOM as a workflow artifact
+- **poetry check --lock** — fails the build if `src/cofounder_agent/poetry.lock` has drifted from `pyproject.toml` (defense-in-depth alongside the local pre-commit hook and the `.gitea/workflows/ci.yml` test job)
 
 Dependencies are kept current by Dependabot (`.github/dependabot.yml`) with a weekly PR batch. Patch and minor bumps auto-rebase onto `dev`; majors wait on human review.
 


### PR DESCRIPTION
## Summary

Closes #180.

- Add a `poetry check --lock` hook to `.pre-commit-config.yaml` (`local` repo, `language: system`) scoped to staged changes touching `src/cofounder_agent/{pyproject.toml,poetry.lock}` so `poetry.lock` drift is blocked before the diff lands.
- Add a `poetry-lock` job to `.github/workflows/security.yml` that runs `cd src/cofounder_agent && poetry check --lock` on every PR + push to `main`. Defense-in-depth: the same check already runs locally (pre-commit) and on the Gitea CI test workflow (`.gitea/workflows/ci.yml` step "Verify poetry.lock matches pyproject.toml").
- Document the install step + the new gate in `CONTRIBUTING.md` ("Run `pre-commit install` after cloning; `poetry check --lock` runs automatically and prevents poetry.lock drift").

The hook intentionally does not cover `mcp-server/` or `src/cofounder_agent/poindexter/` — those projects use `uv` (see `uv.lock`), not Poetry.

## Lock-drift state

`poetry check --lock` against `src/cofounder_agent/` passes locally as of this branch (exit 0, only Poetry 2.x deprecation warnings about `[tool.poetry.*]` keys that don't affect lock consistency). No follow-up PR needed for drift.

## Test plan

- [x] `pre-commit validate-config` exits 0
- [x] `pre-commit run poetry-check-lock --all-files` passes locally (exit 0)
- [x] `pre-commit run poetry-check-lock --files README.md` correctly reports `(no files to check) Skipped` — file-scoping works
- [x] `pre-commit run poetry-check-lock --files src/cofounder_agent/poetry.lock` runs and passes
- [x] YAML lint clean for `.pre-commit-config.yaml` and `.github/workflows/security.yml`
- [ ] CI: `Security / poetry check --lock (src/cofounder_agent)` job goes green on this PR