### PR TITLE
feat(brain): periodic probe for operator-facing URL/IP drift (#214)

### DIFF
--- a/brain/brain_daemon.py
+++ b/brain/brain_daemon.py
@@ -50,6 +50,19 @@ try:
 except ImportError:
     _HAS_BUSINESS_PROBES = False
 
+try:
+    # GH#214 — operator-facing URL/IP drift probe. Runs on its own 15-min
+    # cadence, gated inside maybe_run_operator_url_probe so we don't need
+    # a separate scheduler.
+    from operator_url_probe import maybe_run_operator_url_probe
+    _HAS_OPERATOR_URL_PROBE = True
+except ImportError:  # pragma: no cover — package-qualified for tests
+    try:
+        from brain.operator_url_probe import maybe_run_operator_url_probe
+        _HAS_OPERATOR_URL_PROBE = True
+    except ImportError:
+        _HAS_OPERATOR_URL_PROBE = False
+
 LOG_DIR = os.path.join(os.path.expanduser("~"), os.getenv("APP_LOG_DIR", ".content-pipeline"))
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_FILE = os.path.join(LOG_DIR, "brain.log")
@@ -1007,6 +1020,27 @@ async def run_cycle(pool):
             probe_results.update(biz_results)
         except Exception as e:
             logger.warning("[BRAIN] Business probes failed: %s", e)
+
+    # Operator URL/IP drift probe (#214). Internally gated to ~15 min so it
+    # doesn't run every 5-min cycle. Returns None when the gate skips, a
+    # summary dict on real runs.
+    if _HAS_OPERATOR_URL_PROBE:
+        try:
+            url_summary = await maybe_run_operator_url_probe(pool, notify_fn=None)
+            if url_summary is not None:
+                probe_results["operator_url_probe"] = {
+                    "ok": (
+                        url_summary.get("url_failures", 0) == 0
+                        and url_summary.get("tailscale_drift_count", 0) == 0
+                    ),
+                    "detail": (
+                        f"{url_summary.get('url_failures', 0)} URL failures, "
+                        f"{url_summary.get('tailscale_drift_count', 0)} drifted device(s)"
+                    ),
+                    "summary": url_summary,
+                }
+        except Exception as e:
+            logger.warning("[BRAIN] operator_url_probe failed: %s", e)
 
     all_issues = issues + ext_issues
 

--- a/brain/operator_url_probe.py
+++ b/brain/operator_url_probe.py
@@ -1,0 +1,611 @@
+"""Operator URL probe — flag operator-facing URLs/IPs that have drifted or gone dark.
+
+Closes GitHub Glad-Labs/poindexter#214.
+
+The brain daemon already monitors *services* (FastAPI, Ollama, Postgres). What it
+historically did NOT monitor is the *surfaces* operators actually click on —
+Grafana dashboard links pointing at internal Tailscale IPs, app_setting URLs that
+got renamed but never updated in the dashboards, public storefront URLs that
+404'd because of a routing change. This probe walks every operator-facing surface
+the system knows about and pings them. Anything that doesn't respond gets a
+``notify_operator()`` call with the surface name + recommended fix.
+
+Surfaces inspected each cycle:
+
+1. **Dashboard links** — every `infrastructure/grafana/dashboards/*.json`. We pull
+   URLs from dashboard-level ``links``, panel-level ``links`` AND
+   ``fieldConfig.defaults.links`` (data-link templates).
+2. **system_devices.tailscale_ip** — compared against the live ``tailscale
+   status --json`` output. Drift between DB and Tailscale is the exact bug class
+   that triggered #214.
+3. **app_settings keys ending in ``_url``** — ``site_url``, ``storefront_url``,
+   ``oauth_issuer_url`` and friends. These are what the Grafana templates
+   substitute in.
+4. **Internal compose URLs** — ``prefect_api_url``, ``grafana_url``, ``loki_url``
+   and similar app_settings keys (matched by a curated list, not just suffix,
+   because some don't end in ``_url``).
+
+Concurrency cap: ~10 in-flight HTTP probes via an ``asyncio.Semaphore`` — short
+connect/read timeouts so a single dead URL can't stall the cycle. We never run
+more than once per surface per cycle, and we cap operator notifications at 1 per
+surface per cycle to avoid blasting Telegram when (e.g.) the whole observability
+stack is down at the same time.
+
+Standalone module — only depends on stdlib + ``httpx`` (already a project dep).
+``tailscale`` CLI is optional; if it's missing we skip drift detection without
+failing the probe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Iterable
+
+try:  # pragma: no cover — only fails when the dep is uninstalled
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+try:
+    from operator_notifier import notify_operator
+except ImportError:  # pragma: no cover — package-qualified path for tests
+    from brain.operator_notifier import notify_operator
+
+logger = logging.getLogger("brain.operator_url_probe")
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# Per-request timeouts — kept short so one dead URL doesn't stall the probe.
+# Connect 3s + read 5s is well above the median for any service we monitor.
+HTTP_CONNECT_TIMEOUT_S = 3.0
+HTTP_READ_TIMEOUT_S = 5.0
+
+# Cap concurrent in-flight probes so we don't hammer the network when many
+# dashboards reference the same backend.
+DEFAULT_CONCURRENCY = 10
+
+# Curated list of internal-compose URL keys. These don't all end in ``_url`` —
+# some are bare hostnames or include explicit ports. The probe checks both
+# this set AND any app_setting key matching ``*_url`` so new keys get probed
+# automatically. Order doesn't matter; duplicates are deduped on lookup.
+INTERNAL_COMPOSE_URL_KEYS: tuple[str, ...] = (
+    "prefect_api_url",
+    "grafana_url",
+    "loki_url",
+    "tempo_url",
+    "prometheus_url",
+    "ollama_base_url",
+    "ollama_url",
+    "internal_api_base_url",
+    "api_base_url",
+    "openclaw_gateway_url",
+    "sdxl_server_url",
+)
+
+# Suffix that triggers automatic probing for any app_settings key. Matches
+# the convention used throughout the codebase (site_url, storefront_url,
+# oauth_issuer_url, ...).
+URL_KEY_SUFFIX = "_url"
+
+# Default location for Grafana dashboard JSON. Resolved relative to the repo
+# root because the brain daemon usually runs from there. The probe accepts
+# an explicit override (used in tests) so it doesn't depend on cwd.
+DEFAULT_DASHBOARDS_DIR = Path(__file__).resolve().parent.parent / "infrastructure" / "grafana" / "dashboards"
+
+# Probe schedule: every 15 minutes per #214's "every ~15 min" guidance.
+PROBE_INTERVAL_SECONDS = 15 * 60
+
+# Identifying UA so probes show up clearly in any reverse-proxy logs and
+# don't get tarpitted by Cloudflare's bot fight mode.
+_USER_AGENT = "Poindexter-OperatorURLProbe/1.0 (+https://www.gladlabs.io)"
+
+# Module-level state — track last run + per-surface notify-once accounting.
+_last_run_ts: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Dashboard link extraction
+# ---------------------------------------------------------------------------
+
+
+def _walk_panel_links(panel: dict[str, Any]) -> Iterable[tuple[str, str]]:
+    """Yield (title, url) pairs from a single panel's link configuration.
+
+    Grafana stores links in TWO places per panel:
+
+    * ``panel["links"]`` — top-of-panel quick-jump links
+    * ``panel["fieldConfig"]["defaults"]["links"]`` — per-data-point drill-down
+      links (used in stat panels, heatmaps, etc.)
+
+    We extract from both. Templating placeholders (``${var}``) are left as-is
+    — the probe will skip them rather than try to substitute, so a templated
+    URL won't generate a false positive.
+    """
+    title = panel.get("title") or "(untitled panel)"
+    for link in panel.get("links") or []:
+        url = (link or {}).get("url")
+        if url:
+            yield (f"{title} :: {link.get('title') or 'link'}", url)
+    field_config = panel.get("fieldConfig") or {}
+    defaults = field_config.get("defaults") or {}
+    for link in defaults.get("links") or []:
+        url = (link or {}).get("url")
+        if url:
+            yield (f"{title} :: data-link {link.get('title') or ''}".rstrip(), url)
+    # Recurse into nested rows (Grafana puts panels inside row.panels)
+    for nested in panel.get("panels") or []:
+        if isinstance(nested, dict):
+            yield from _walk_panel_links(nested)
+
+
+def extract_dashboard_links(dashboards_dir: Path) -> list[dict[str, str]]:
+    """Walk every dashboard JSON file and return [{dashboard, surface, url}, ...].
+
+    A "surface" is the operator-readable identifier of where the URL appears,
+    e.g. ``"Mission Control :: Prefect UI"``. Skips templated URLs (containing
+    ``${``) so we don't probe ``http://${ip}:4200`` and report it as broken.
+    """
+    if not dashboards_dir.exists():
+        logger.warning(
+            "[OPERATOR_URL_PROBE] Dashboards dir not found: %s", dashboards_dir
+        )
+        return []
+
+    found: list[dict[str, str]] = []
+    for path in sorted(dashboards_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "[OPERATOR_URL_PROBE] Could not parse %s: %s", path.name, exc
+            )
+            continue
+
+        dashboard_title = data.get("title") or path.stem
+
+        # Dashboard-level links
+        for link in data.get("links") or []:
+            url = (link or {}).get("url")
+            if not url:
+                continue
+            found.append({
+                "dashboard": dashboard_title,
+                "surface": f"{dashboard_title} :: {link.get('title') or 'link'}",
+                "url": url,
+            })
+
+        # Panel-level links + field-config data links
+        for panel in data.get("panels") or []:
+            if not isinstance(panel, dict):
+                continue
+            for surface_suffix, url in _walk_panel_links(panel):
+                found.append({
+                    "dashboard": dashboard_title,
+                    "surface": f"{dashboard_title} :: {surface_suffix}",
+                    "url": url,
+                })
+
+    # Drop templated URLs — we can't resolve ${var} without dashboard context,
+    # and probing the literal would generate noisy false positives.
+    deduped: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in found:
+        if "${" in item["url"] or "$__" in item["url"]:
+            continue
+        key = (item["surface"], item["url"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+# ---------------------------------------------------------------------------
+# Tailscale drift detection
+# ---------------------------------------------------------------------------
+
+
+def _run_tailscale_status() -> dict[str, str] | None:
+    """Run ``tailscale status --json`` and return ``{hostname: tailscale_ip}``.
+
+    Returns ``None`` if the CLI isn't available or the command fails — drift
+    detection is best-effort. We never crash the probe on a missing tailscale
+    install.
+    """
+    try:
+        kwargs: dict[str, Any] = {"capture_output": True, "text": True, "timeout": 10}
+        if os.name == "nt":
+            kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
+        result = subprocess.run(["tailscale", "status", "--json"], **kwargs)
+    except FileNotFoundError:
+        logger.info("[OPERATOR_URL_PROBE] tailscale CLI not on PATH — skipping drift detection")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("[OPERATOR_URL_PROBE] tailscale status timed out")
+        return None
+    except Exception as exc:
+        logger.warning("[OPERATOR_URL_PROBE] tailscale status failed: %s", exc)
+        return None
+
+    if result.returncode != 0:
+        logger.warning(
+            "[OPERATOR_URL_PROBE] tailscale status returned %d: %s",
+            result.returncode, (result.stderr or "")[:200],
+        )
+        return None
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logger.warning("[OPERATOR_URL_PROBE] tailscale status JSON parse failed: %s", exc)
+        return None
+
+    name_to_ip: dict[str, str] = {}
+
+    # The local node lives at data["Self"], peers at data["Peer"][nodekey].
+    # Both expose ``HostName`` (short) and ``DNSName`` (FQDN) plus a
+    # ``TailscaleIPs`` list whose first entry is the v4 address.
+    def _add(node: dict[str, Any]) -> None:
+        ips = node.get("TailscaleIPs") or []
+        if not ips:
+            return
+        v4 = next((ip for ip in ips if ":" not in ip), ips[0])
+        for label_key in ("HostName", "DNSName"):
+            label = node.get(label_key)
+            if label:
+                # Strip the trailing dot Tailscale appends to MagicDNS names.
+                name_to_ip.setdefault(label.split(".")[0].lower(), v4)
+
+    self_node = data.get("Self")
+    if isinstance(self_node, dict):
+        _add(self_node)
+    for peer in (data.get("Peer") or {}).values():
+        if isinstance(peer, dict):
+            _add(peer)
+    return name_to_ip
+
+
+async def detect_tailscale_drift(pool) -> list[dict[str, str]]:
+    """Return list of system_devices rows whose tailscale_ip drifted.
+
+    Each row: ``{"surface", "name", "db_ip", "live_ip", "fix"}``. Empty list
+    when there's no drift, when tailscale isn't installed, or when the
+    system_devices table doesn't exist (fresh install).
+    """
+    live = _run_tailscale_status()
+    if live is None:
+        return []
+
+    try:
+        rows = await pool.fetch("SELECT name, tailscale_ip FROM system_devices")
+    except Exception as exc:
+        # Table may not exist on a fresh install — log + bail.
+        if "does not exist" in str(exc):
+            logger.info("[OPERATOR_URL_PROBE] system_devices table missing — skipping drift")
+            return []
+        logger.warning("[OPERATOR_URL_PROBE] system_devices read failed: %s", exc)
+        return []
+
+    drift: list[dict[str, str]] = []
+    for row in rows:
+        name = (row["name"] or "").lower()
+        db_ip = row["tailscale_ip"]
+        live_ip = live.get(name)
+        if live_ip and db_ip and live_ip != db_ip:
+            drift.append({
+                "surface": f"system_devices.{name}",
+                "name": name,
+                "db_ip": db_ip,
+                "live_ip": live_ip,
+                "fix": (
+                    f"UPDATE system_devices SET tailscale_ip = '{live_ip}', "
+                    f"updated_at = NOW() WHERE name = '{name}';"
+                ),
+            })
+    return drift
+
+
+# ---------------------------------------------------------------------------
+# app_settings URL collection
+# ---------------------------------------------------------------------------
+
+
+async def collect_app_setting_urls(pool) -> list[dict[str, str]]:
+    """Return ``[{surface, key, url}, ...]`` for every probable URL in app_settings.
+
+    "Probable URL" = the key ends in ``_url`` OR it's in
+    ``INTERNAL_COMPOSE_URL_KEYS``. We skip empty strings and entries that
+    don't look like URLs (no ``://``) so misconfigured rows don't clutter
+    the report.
+    """
+    try:
+        rows = await pool.fetch(
+            "SELECT key, value FROM app_settings WHERE value IS NOT NULL AND value <> ''"
+        )
+    except Exception as exc:
+        logger.warning("[OPERATOR_URL_PROBE] app_settings read failed: %s", exc)
+        return []
+
+    explicit = set(INTERNAL_COMPOSE_URL_KEYS)
+    out: list[dict[str, str]] = []
+    seen_urls: set[tuple[str, str]] = set()
+    for row in rows:
+        key = row["key"]
+        if not (key.endswith(URL_KEY_SUFFIX) or key in explicit):
+            continue
+        value = (row["value"] or "").strip()
+        # Has to look like a URL to be probable; bare hostnames aren't
+        # something HEAD/GET can hit reliably.
+        if "://" not in value:
+            continue
+        dedup_key = (key, value)
+        if dedup_key in seen_urls:
+            continue
+        seen_urls.add(dedup_key)
+        out.append({
+            "surface": f"app_settings.{key}",
+            "key": key,
+            "url": value,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTTP probing
+# ---------------------------------------------------------------------------
+
+
+async def _probe_one_url(
+    client: "httpx.AsyncClient",
+    semaphore: asyncio.Semaphore,
+    surface: str,
+    url: str,
+) -> dict[str, Any]:
+    """HEAD an URL; if HEAD isn't supported, retry with GET. Always returns a
+    dict, never raises — surface name is preserved for downstream notify."""
+    async with semaphore:
+        try:
+            resp = await client.head(url, follow_redirects=True)
+            # Some servers return 405 for HEAD even when GET works. Retry
+            # once with a small range request to avoid pulling a full body.
+            if resp.status_code in (405, 501):
+                resp = await client.get(url, headers={"Range": "bytes=0-64"})
+            return {
+                "surface": surface,
+                "url": url,
+                "ok": 200 <= resp.status_code < 400,
+                "status": resp.status_code,
+                "detail": f"HTTP {resp.status_code}",
+            }
+        except Exception as exc:
+            return {
+                "surface": surface,
+                "url": url,
+                "ok": False,
+                "status": 0,
+                "detail": f"{type(exc).__name__}: {str(exc)[:160]}",
+            }
+
+
+async def probe_urls(
+    targets: list[dict[str, str]],
+    *,
+    concurrency: int = DEFAULT_CONCURRENCY,
+) -> list[dict[str, Any]]:
+    """Probe ``targets`` (list of {surface, url, ...}) and return per-URL results.
+
+    Returns one dict per input target. Failures are reported, not raised — the
+    caller decides whether to escalate. ``httpx`` is required; if it's missing
+    every target is reported as ``ok=False`` so the operator notices the dep
+    is broken instead of silently passing.
+    """
+    if not targets:
+        return []
+
+    if httpx is None:  # pragma: no cover — only when dep is uninstalled
+        logger.error(
+            "[OPERATOR_URL_PROBE] httpx is not installed — cannot probe URLs"
+        )
+        return [
+            {
+                "surface": t["surface"],
+                "url": t["url"],
+                "ok": False,
+                "status": 0,
+                "detail": "httpx dependency missing",
+            }
+            for t in targets
+        ]
+
+    timeout = httpx.Timeout(HTTP_READ_TIMEOUT_S, connect=HTTP_CONNECT_TIMEOUT_S)
+    headers = {"User-Agent": _USER_AGENT}
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        headers=headers,
+        # follow_redirects=True is set per-request so we still surface
+        # redirects when a HEAD bounces; the per-request settings win.
+    ) as client:
+        coros = [
+            _probe_one_url(client, semaphore, t["surface"], t["url"])
+            for t in targets
+        ]
+        # return_exceptions guards against a misbehaving probe taking down the
+        # whole gather — _probe_one_url is already exception-safe but defence
+        # in depth keeps the cycle running.
+        results = await asyncio.gather(*coros, return_exceptions=True)
+
+    out: list[dict[str, Any]] = []
+    for r, t in zip(results, targets):
+        if isinstance(r, Exception):
+            out.append({
+                "surface": t["surface"],
+                "url": t["url"],
+                "ok": False,
+                "status": 0,
+                "detail": f"unexpected: {type(r).__name__}: {str(r)[:120]}",
+            })
+        else:
+            out.append(r)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Top-level probe entry point
+# ---------------------------------------------------------------------------
+
+
+def _format_url_failure_detail(failure: dict[str, Any]) -> str:
+    return (
+        f"URL: {failure['url']}\n"
+        f"Status: {failure['detail']}\n"
+        f"Recommended fix: update the surface to point at a reachable URL, "
+        f"or remove the link if the service was retired."
+    )
+
+
+def _format_drift_detail(drift: dict[str, str]) -> str:
+    return (
+        f"Device: {drift['name']}\n"
+        f"DB tailscale_ip: {drift['db_ip']}\n"
+        f"Live tailscale_ip: {drift['live_ip']}\n"
+        f"Recommended fix:\n  {drift['fix']}"
+    )
+
+
+async def run_operator_url_probe(
+    pool,
+    *,
+    dashboards_dir: Path | None = None,
+    notify_fn=None,
+    concurrency: int = DEFAULT_CONCURRENCY,
+) -> dict[str, Any]:
+    """Single execution of the probe. Returns a summary dict.
+
+    The brain daemon's periodic-cycle scheduler is the canonical caller (see
+    ``_maybe_run_operator_url_probe``). Tests can call this directly.
+
+    ``notify_fn`` defaults to :func:`brain.operator_notifier.notify_operator`
+    but accepts an injected stub for tests. We cap notifications at 1 per
+    surface per cycle so a fully-down stack doesn't blast Telegram.
+    """
+    dashboards_dir = dashboards_dir or DEFAULT_DASHBOARDS_DIR
+    notify_fn = notify_fn or notify_operator
+
+    # ---- 1) Collect all URL targets from the four sources -----------------
+    dashboard_targets = extract_dashboard_links(dashboards_dir)
+    appsetting_targets = await collect_app_setting_urls(pool)
+
+    # Merge URL lists — keep the first surface that points at a given URL
+    # so the failure notification has a clear "this is where the link
+    # lives" anchor. (The same backend URL can appear in many panels.)
+    all_targets: list[dict[str, str]] = []
+    seen_urls: set[str] = set()
+    for t in dashboard_targets + appsetting_targets:
+        if t["url"] in seen_urls:
+            continue
+        seen_urls.add(t["url"])
+        all_targets.append(t)
+
+    logger.info(
+        "[OPERATOR_URL_PROBE] Probing %d URL(s) (%d dashboard, %d app_settings)",
+        len(all_targets), len(dashboard_targets), len(appsetting_targets),
+    )
+
+    # ---- 2) HTTP probe everything in parallel -----------------------------
+    url_results = await probe_urls(all_targets, concurrency=concurrency)
+
+    # ---- 3) Tailscale drift detection -------------------------------------
+    drift = await detect_tailscale_drift(pool)
+
+    # ---- 4) Notify per-surface — cap at 1 per surface per cycle ----------
+    notified: set[str] = set()
+    failures = [r for r in url_results if not r["ok"]]
+    for failure in failures:
+        if failure["surface"] in notified:
+            continue
+        notified.add(failure["surface"])
+        try:
+            notify_fn(
+                title=f"Operator surface unreachable: {failure['surface']}",
+                detail=_format_url_failure_detail(failure),
+                source="brain.operator_url_probe",
+                severity="warning",
+            )
+        except Exception as exc:  # notify must never crash the cycle
+            logger.warning(
+                "[OPERATOR_URL_PROBE] notify_fn failed for %s: %s",
+                failure["surface"], exc,
+            )
+
+    for d in drift:
+        if d["surface"] in notified:
+            continue
+        notified.add(d["surface"])
+        try:
+            notify_fn(
+                title=f"Tailscale IP drift: {d['name']}",
+                detail=_format_drift_detail(d),
+                source="brain.operator_url_probe",
+                severity="warning",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[OPERATOR_URL_PROBE] notify_fn failed for %s: %s",
+                d["surface"], exc,
+            )
+
+    summary = {
+        "total_urls_probed": len(url_results),
+        "url_failures": len(failures),
+        "tailscale_drift_count": len(drift),
+        "notifications_sent": len(notified),
+        # Keep the failing surfaces in the summary for callers who want to
+        # log them or persist into brain_knowledge.
+        "failing_surfaces": [
+            {"surface": f["surface"], "url": f["url"], "detail": f["detail"]}
+            for f in failures
+        ],
+        "drifted_devices": drift,
+    }
+    logger.info(
+        "[OPERATOR_URL_PROBE] Cycle complete: %d/%d URLs failing, %d drifted device(s), %d notifications",
+        summary["url_failures"], summary["total_urls_probed"],
+        summary["tailscale_drift_count"], summary["notifications_sent"],
+    )
+    return summary
+
+
+async def maybe_run_operator_url_probe(pool, *, notify_fn=None) -> dict[str, Any] | None:
+    """Run the probe iff its 15-minute interval has elapsed.
+
+    Designed to be called from the brain daemon's main cycle (which runs
+    every 5 minutes). The interval gate keeps the probe at #214's "every
+    ~15 min" cadence without spinning up a separate scheduler.
+
+    Returns the summary dict on a real run, ``None`` when the gate skips.
+    """
+    global _last_run_ts
+    import time as _time
+    now = _time.time()
+    if (now - _last_run_ts) < PROBE_INTERVAL_SECONDS:
+        return None
+    _last_run_ts = now
+    try:
+        return await run_operator_url_probe(pool, notify_fn=notify_fn)
+    except Exception as exc:
+        # Defence in depth — the brain cycle's _step wrapper will catch this
+        # too, but logging here gives the failure context (the probe name)
+        # without the operator having to grep brain_decisions.
+        logger.warning(
+            "[OPERATOR_URL_PROBE] probe crashed: %s", exc, exc_info=True
+        )
+        return {"error": f"{type(exc).__name__}: {exc}"}

--- a/src/cofounder_agent/tests/unit/services/test_brain_operator_url_probe.py
+++ b/src/cofounder_agent/tests/unit/services/test_brain_operator_url_probe.py
@@ -1,0 +1,381 @@
+"""Unit tests for brain/operator_url_probe.py (GH#214).
+
+Covers dashboard JSON link extraction, app_settings URL collection, tailscale
+drift detection, the HTTP probe entry point, and the maybe_run interval gate.
+All external I/O (httpx, asyncpg, subprocess) is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from brain import operator_url_probe as oup
+
+
+def _make_pool(rows=None):
+    """Build a mock asyncpg pool whose fetch/fetchrow return canned rows."""
+    pool = MagicMock()
+    pool.fetch = AsyncMock(return_value=rows or [])
+    pool.fetchrow = AsyncMock()
+    pool.execute = AsyncMock()
+    return pool
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    oup._last_run_ts = 0.0
+    yield
+    oup._last_run_ts = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Dashboard link extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractDashboardLinks:
+    def test_pulls_dashboard_level_links(self, tmp_path: Path):
+        dash = {
+            "title": "Mission Control",
+            "links": [
+                {"title": "Prefect UI", "url": "http://100.81.93.12:4200"},
+                {"title": "Grafana", "url": "http://localhost:3000"},
+            ],
+            "panels": [],
+        }
+        (tmp_path / "mission.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        urls = {item["url"] for item in out}
+        assert "http://100.81.93.12:4200" in urls
+        assert "http://localhost:3000" in urls
+        # Surface includes dashboard title + link title.
+        assert any("Mission Control :: Prefect UI" == i["surface"] for i in out)
+
+    def test_pulls_panel_level_links(self, tmp_path: Path):
+        dash = {
+            "title": "D1",
+            "panels": [
+                {
+                    "title": "API Stats",
+                    "links": [{"title": "Health", "url": "http://api/health"}],
+                }
+            ],
+        }
+        (tmp_path / "d1.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        assert any(i["url"] == "http://api/health" for i in out)
+        # Surface should reference the panel title.
+        assert any("API Stats" in i["surface"] for i in out)
+
+    def test_pulls_data_links(self, tmp_path: Path):
+        dash = {
+            "title": "D2",
+            "panels": [
+                {
+                    "title": "P",
+                    "fieldConfig": {
+                        "defaults": {
+                            "links": [{"title": "drill", "url": "http://drill.local"}]
+                        }
+                    },
+                }
+            ],
+        }
+        (tmp_path / "d2.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        assert any(i["url"] == "http://drill.local" for i in out)
+
+    def test_recurses_into_row_panels(self, tmp_path: Path):
+        dash = {
+            "title": "D3",
+            "panels": [
+                {
+                    "title": "Row",
+                    "panels": [
+                        {
+                            "title": "Inner",
+                            "links": [{"title": "x", "url": "http://inner"}],
+                        }
+                    ],
+                }
+            ],
+        }
+        (tmp_path / "d3.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        assert any(i["url"] == "http://inner" for i in out)
+
+    def test_skips_templated_urls(self, tmp_path: Path):
+        dash = {
+            "title": "D4",
+            "links": [
+                {"title": "OK", "url": "http://real.local"},
+                {"title": "Bad", "url": "http://${ip}:4200"},
+                {"title": "Var", "url": "http://x/$__url_time"},
+            ],
+            "panels": [],
+        }
+        (tmp_path / "d4.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        urls = [i["url"] for i in out]
+        assert "http://real.local" in urls
+        assert all("${" not in u and "$__" not in u for u in urls)
+
+    def test_dedupes_repeated_url(self, tmp_path: Path):
+        dash = {
+            "title": "D5",
+            "links": [
+                {"title": "A", "url": "http://x"},
+                {"title": "A", "url": "http://x"},
+            ],
+            "panels": [],
+        }
+        (tmp_path / "d5.json").write_text(json.dumps(dash))
+        out = oup.extract_dashboard_links(tmp_path)
+        assert len(out) == 1
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path):
+        out = oup.extract_dashboard_links(tmp_path / "does-not-exist")
+        assert out == []
+
+    def test_malformed_json_does_not_raise(self, tmp_path: Path):
+        (tmp_path / "broken.json").write_text("{not valid json")
+        out = oup.extract_dashboard_links(tmp_path)
+        assert out == []  # silently skipped
+
+
+# ---------------------------------------------------------------------------
+# app_settings URL collection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCollectAppSettingUrls:
+    @pytest.mark.asyncio
+    async def test_picks_up_url_suffix_keys(self):
+        pool = _make_pool([
+            {"key": "site_url", "value": "https://gladlabs.io"},
+            {"key": "storefront_url", "value": "https://gladlabs.ai"},
+            {"key": "unrelated_key", "value": "not a url"},
+        ])
+        out = await oup.collect_app_setting_urls(pool)
+        keys = {i["key"] for i in out}
+        assert keys == {"site_url", "storefront_url"}
+
+    @pytest.mark.asyncio
+    async def test_picks_up_internal_compose_keys(self):
+        pool = _make_pool([
+            {"key": "prefect_api_url", "value": "http://prefect:4200/api"},
+            {"key": "grafana_url", "value": "http://grafana:3000"},
+            {"key": "loki_url", "value": "http://loki:3100"},
+        ])
+        out = await oup.collect_app_setting_urls(pool)
+        assert len(out) == 3
+        assert all(i["surface"].startswith("app_settings.") for i in out)
+
+    @pytest.mark.asyncio
+    async def test_skips_values_without_scheme(self):
+        pool = _make_pool([
+            {"key": "site_url", "value": "gladlabs.io"},  # no scheme
+            {"key": "real_url", "value": "https://x.com"},
+        ])
+        out = await oup.collect_app_setting_urls(pool)
+        urls = {i["url"] for i in out}
+        assert urls == {"https://x.com"}
+
+    @pytest.mark.asyncio
+    async def test_db_failure_returns_empty(self):
+        pool = _make_pool()
+        pool.fetch = AsyncMock(side_effect=Exception("boom"))
+        out = await oup.collect_app_setting_urls(pool)
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Tailscale drift detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTailscaleDrift:
+    @pytest.mark.asyncio
+    async def test_no_drift_returns_empty(self):
+        pool = _make_pool([
+            {"name": "workstation", "tailscale_ip": "100.81.93.12"},
+        ])
+        live = {"workstation": "100.81.93.12"}
+        with patch.object(oup, "_run_tailscale_status", return_value=live):
+            out = await oup.detect_tailscale_drift(pool)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_drift_returned_with_fix(self):
+        pool = _make_pool([
+            {"name": "workstation", "tailscale_ip": "100.64.0.1"},  # stale
+            {"name": "pixel-9", "tailscale_ip": "100.42.0.1"},
+        ])
+        live = {"workstation": "100.81.93.12", "pixel-9": "100.42.0.1"}
+        with patch.object(oup, "_run_tailscale_status", return_value=live):
+            out = await oup.detect_tailscale_drift(pool)
+        assert len(out) == 1
+        d = out[0]
+        assert d["name"] == "workstation"
+        assert d["db_ip"] == "100.64.0.1"
+        assert d["live_ip"] == "100.81.93.12"
+        assert "UPDATE system_devices" in d["fix"]
+
+    @pytest.mark.asyncio
+    async def test_tailscale_unavailable_returns_empty(self):
+        pool = _make_pool()
+        with patch.object(oup, "_run_tailscale_status", return_value=None):
+            out = await oup.detect_tailscale_drift(pool)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_table_missing_returns_empty(self):
+        pool = _make_pool()
+        pool.fetch = AsyncMock(side_effect=Exception("system_devices does not exist"))
+        with patch.object(oup, "_run_tailscale_status", return_value={"x": "1"}):
+            out = await oup.detect_tailscale_drift(pool)
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Top-level run_operator_url_probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunOperatorUrlProbe:
+    @pytest.mark.asyncio
+    async def test_notifies_once_per_failed_surface(self, tmp_path: Path):
+        # Two dashboard links, both unreachable. notify_fn should be called
+        # twice (once per surface) — the cap is 1 per surface, not 1 total.
+        dash = {
+            "title": "D",
+            "links": [
+                {"title": "A", "url": "http://broken-a.local"},
+                {"title": "B", "url": "http://broken-b.local"},
+            ],
+            "panels": [],
+        }
+        (tmp_path / "d.json").write_text(json.dumps(dash))
+
+        pool = _make_pool([])  # no app_settings rows
+        notifies: list[dict] = []
+
+        def fake_notify(**kwargs):
+            notifies.append(kwargs)
+
+        async def fake_probe(targets, *, concurrency=10):
+            return [
+                {"surface": t["surface"], "url": t["url"], "ok": False,
+                 "status": 0, "detail": "ConnectError"}
+                for t in targets
+            ]
+
+        with patch.object(oup, "probe_urls", side_effect=fake_probe), \
+             patch.object(oup, "_run_tailscale_status", return_value=None):
+            summary = await oup.run_operator_url_probe(
+                pool, dashboards_dir=tmp_path, notify_fn=fake_notify
+            )
+
+        assert summary["url_failures"] == 2
+        assert summary["notifications_sent"] == 2
+        assert len(notifies) == 2
+        assert all("Operator surface unreachable" in n["title"] for n in notifies)
+
+    @pytest.mark.asyncio
+    async def test_no_notify_when_all_ok(self, tmp_path: Path):
+        dash = {"title": "D", "links": [{"title": "A", "url": "http://ok"}], "panels": []}
+        (tmp_path / "d.json").write_text(json.dumps(dash))
+        pool = _make_pool([])
+        notifies = []
+
+        async def fake_probe(targets, *, concurrency=10):
+            return [
+                {"surface": t["surface"], "url": t["url"], "ok": True,
+                 "status": 200, "detail": "HTTP 200"}
+                for t in targets
+            ]
+
+        with patch.object(oup, "probe_urls", side_effect=fake_probe), \
+             patch.object(oup, "_run_tailscale_status", return_value=None):
+            summary = await oup.run_operator_url_probe(
+                pool, dashboards_dir=tmp_path,
+                notify_fn=lambda **k: notifies.append(k),
+            )
+
+        assert summary["url_failures"] == 0
+        assert summary["notifications_sent"] == 0
+
+    @pytest.mark.asyncio
+    async def test_drift_triggers_notify(self, tmp_path: Path):
+        # Pool needs to return [] for the app_settings query and the
+        # device row for the system_devices query, so route by SQL keyword.
+        pool = MagicMock()
+
+        async def fake_fetch(query, *args, **kwargs):
+            if "system_devices" in query:
+                return [{"name": "workstation", "tailscale_ip": "100.64.0.1"}]
+            return []  # app_settings et al
+
+        pool.fetch = fake_fetch
+        pool.execute = AsyncMock()
+        notifies = []
+
+        async def fake_probe(targets, *, concurrency=10):
+            return []
+
+        with patch.object(oup, "probe_urls", side_effect=fake_probe), \
+             patch.object(oup, "_run_tailscale_status",
+                          return_value={"workstation": "100.81.93.12"}):
+            summary = await oup.run_operator_url_probe(
+                pool, dashboards_dir=tmp_path,
+                notify_fn=lambda **k: notifies.append(k),
+            )
+
+        assert summary["tailscale_drift_count"] == 1
+        assert any("Tailscale IP drift" in n["title"] for n in notifies)
+
+
+# ---------------------------------------------------------------------------
+# Interval gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMaybeRun:
+    @pytest.mark.asyncio
+    async def test_first_call_runs(self):
+        pool = _make_pool()
+        with patch.object(oup, "run_operator_url_probe",
+                          new=AsyncMock(return_value={"ok": True})) as m:
+            result = await oup.maybe_run_operator_url_probe(pool)
+        assert result == {"ok": True}
+        assert m.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_second_call_within_window_skips(self):
+        pool = _make_pool()
+        with patch.object(oup, "run_operator_url_probe",
+                          new=AsyncMock(return_value={"ok": True})) as m:
+            first = await oup.maybe_run_operator_url_probe(pool)
+            second = await oup.maybe_run_operator_url_probe(pool)
+        assert first == {"ok": True}
+        assert second is None  # gated
+        assert m.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_crash_returned_as_error_dict(self):
+        pool = _make_pool()
+        with patch.object(oup, "run_operator_url_probe",
+                          new=AsyncMock(side_effect=RuntimeError("boom"))):
+            result = await oup.maybe_run_operator_url_probe(pool)
+        assert result is not None
+        assert "error" in result
+        assert "RuntimeError" in result["error"]


### PR DESCRIPTION
## Summary

Closes #214. Adds a 15-minute brain probe that walks every operator-facing surface the system knows about and flags anything that's drifted or gone dark — the exact paper-cut #214 was filed for (Grafana dashboard pointed at a stale Tailscale IP, dead-ended from Matt's phone with no logs).

Surfaces probed each cycle:

- **Dashboard links** — every `infrastructure/grafana/dashboards/*.json`. Pulls URLs from dashboard-level `links`, panel-level `links`, AND `fieldConfig.defaults.links` (data-link templates). Recurses into row.panels. Templated URLs (`${var}`, `$__time`) are skipped so we don't false-positive.
- **`system_devices.tailscale_ip`** — compared against live `tailscale status --json`. Drift report includes the exact `UPDATE` statement to fix it. Skipped silently when the CLI isn't installed.
- **`app_settings` keys ending in `_url`** plus a curated set of internal compose keys (`prefect_api_url`, `grafana_url`, `loki_url`, `tempo_url`, `prometheus_url`, ...).

Implementation notes:

- `httpx.AsyncClient` with 3s connect / 5s read timeouts and an `asyncio.Semaphore(10)` cap so a single slow URL can't stall the cycle.
- `notify_operator()` cap of **1 per surface per cycle** so a stack-wide outage doesn't blast Telegram.
- Wired into the brain daemon's existing `run_cycle` (no new daemon). Gated internally to ~15 min so the 5-min brain cycle doesn't re-run it on every tick.
- Best-effort everywhere — every external call is exception-safe; the probe never raises out of the cycle.

## Files

- `brain/operator_url_probe.py` — new module (probe + interval gate).
- `brain/brain_daemon.py` — import + cycle hookup behind `_HAS_OPERATOR_URL_PROBE`.
- `src/cofounder_agent/tests/unit/services/test_brain_operator_url_probe.py` — 22 unit tests.

## Test plan

- [x] `pytest tests/unit/services/test_brain_operator_url_probe.py` — 22/22 pass locally
- [x] `pytest tests/unit/services/test_brain_health_probes.py tests/unit/services/test_brain_daemon_auto_remediate.py tests/unit/services/test_brain_seed_loader.py` — 46/46 still pass (no regressions in existing brain tests)
- [x] `python -c "from brain import operator_url_probe"` smoke import works
- [x] `py_compile brain/brain_daemon.py` succeeds
- [ ] After merge: confirm a real cycle logs `[OPERATOR_URL_PROBE] Cycle complete: ...` within 15 min and watch Telegram for any unexpected surface failures

## Out of scope

- Sibling check #213 (compose-spec drift detector) noted in #214 — left as a separate probe so each can fail/notify independently.
- Persisting probe results into `brain_knowledge` for trend analysis — current run already returns a summary; a follow-up can wire it into the same table `health_probes` writes to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)