### PR TITLE
fix(audit): demote dry-run halts from error to info severity (#260)

### DIFF
--- a/src/cofounder_agent/services/content_router_service.py
+++ b/src/cofounder_agent/services/content_router_service.py
@@ -296,9 +296,41 @@ async def process_content_generation_task(
     except Exception as e:
         logger.error("[BG-TASK] Pipeline error for task %s...: %s", task_id[:8], e, exc_info=True)
         logger.error("[BG-TASK] Detailed traceback:", exc_info=True)
-        audit_log_bg("error", "content_router", {
-            "error": str(e)[:500], "stages_completed": list(result.get("stages", {}).keys()),
-        }, task_id=task_id, severity="error")
+
+        # Glad-Labs/poindexter#260: when pipeline_dry_run_mode is on, the
+        # writer chain short-circuits with AllModelsFailedError ("no
+        # attempts recorded") because dry-run intentionally suppresses
+        # model calls. That's expected behavior, NOT a real failure —
+        # logging it as severity='error' was drowning the 24h error
+        # count (277/277 in one window were dry-run noise) and hiding
+        # actual ollama/db errors. Demote to severity='info' with a
+        # filterable event_type so dashboards/alerts can ignore it.
+        # The task's own status (set below to 'failed', or 'dry_run' by
+        # finalize_task) remains the authoritative state — only the
+        # audit_log row severity changes here.
+        _is_dry_run_halt = False
+        try:
+            from services.site_config import site_config as _sc_dryrun_check
+            _dry_raw = _sc_dryrun_check.get("pipeline_dry_run_mode", "")
+            _is_dry_run = str(_dry_raw).strip().lower() in ("true", "1", "yes", "on")
+            _err_text = str(e)
+            _is_dry_run_halt = _is_dry_run and (
+                "no attempts recorded" in _err_text
+                or "AllModelsFailedError" in _err_text
+            )
+        except Exception as _dry_exc:
+            logger.debug("[BG-TASK] dry-run severity-demote check failed: %s", _dry_exc)
+
+        if _is_dry_run_halt:
+            audit_log_bg("dry_run_halt", "content_router", {
+                "error": str(e)[:500],
+                "stages_completed": list(result.get("stages", {}).keys()),
+                "reason": "pipeline_dry_run_mode short-circuited the writer chain",
+            }, task_id=task_id, severity="info")
+        else:
+            audit_log_bg("error", "content_router", {
+                "error": str(e)[:500], "stages_completed": list(result.get("stages", {}).keys()),
+            }, task_id=task_id, severity="error")
 
         # Update content_task with failure status
         # 🔑 CRITICAL: Preserve all partially-generated data (content, image, metadata)


### PR DESCRIPTION
## Summary

Fixes #260 — dry-run halts were polluting the 24h audit `severity='error'` count (277 of 277 errors in one window were dry-run noise, hiding real ollama/db failures).

When `pipeline_dry_run_mode=true`, the writer chain raises `AllModelsFailedError ("no attempts recorded")` because dry-run intentionally suppresses model calls. The pipeline error handler in `content_router_service.py` was treating this expected halt as a real failure (`severity='error'`, `event_type='error'`).

This PR detects the dry-run sentinel inside the existing error handler:

- Reads `pipeline_dry_run_mode` from `site_config`.
- Inspects the exception text for the `AllModelsFailedError` / `"no attempts recorded"` pattern.
- When BOTH match, emits `severity='info'` with `event_type='dry_run_halt'` (filterable, includes a `reason` field).
- Otherwise behaves identically to before — real ollama/DB errors still write `severity='error'` rows.

The task's own status (`failed` from this handler, or `dry_run` from `finalize_task`) is unchanged — only the audit_log row severity moves.

## Why option (b) over option (a)

The issue suggested either pre-empting the model resolver or demoting in the existing handler. Option (b) is a 35-line single-file change with zero behavior change for non-dry-run paths; option (a) would have required a new dry-run sentinel class and touched the model-resolver / generator surface. For a noise-only fix, (b) is the lower-risk choice.

## Test plan

- [ ] Run a content task with `pipeline_dry_run_mode=true` → confirm the audit_log row is `severity=info`, `event_type=dry_run_halt`.
- [ ] Trigger a real failure (e.g. force an Ollama timeout) → confirm the audit_log row is still `severity=error`, `event_type=error`.
- [ ] Confirm the `failed` task status is still set in dry-run (the issue requires status semantics unchanged).
- [ ] Verify the 24h `severity='error'` audit count drops to <50 with dry-run on, per the acceptance criteria.