### PR TITLE
fix(mcp): add apscheduler dep so topics_propose works (#258)

### DIFF
--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -7,6 +7,13 @@ dependencies = [
     "mcp[cli]>=1.23.0",
     "asyncpg>=0.30.0",
     "httpx>=0.27.0",
+    # Required transitively by topics_propose: services.topic_proposal_service
+    # → services.stages.topic_decision_gate → plugins (top-level
+    # plugins/__init__.py imports plugins.scheduler, which imports
+    # apscheduler.schedulers.asyncio). Pinned to match
+    # src/cofounder_agent/pyproject.toml ("^3.11.2"). See
+    # Glad-Labs/poindexter#258.
+    "apscheduler>=3.11.2,<4",
 ]
 
 [build-system]

--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -34,6 +34,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -361,6 +373,7 @@ name = "poindexter-mcp"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
@@ -368,6 +381,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "apscheduler", specifier = ">=3.11.2,<4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
@@ -716,6 +730,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes Glad-Labs/poindexter#258 — `topics_propose` (and the rest of the topic-gate MCP tools) crashed with:

```
ModuleNotFoundError: No module named 'apscheduler'
```

The lazy-import inside `topics_propose` doesn't dodge the problem because the chain hits `plugins/__init__.py`, which eagerly imports `plugins.scheduler` -> `apscheduler.schedulers.asyncio` at module load.

Import chain that was crashing:

```
services.topic_proposal_service
  -> services.stages.topic_decision_gate
  -> plugins.stage
  -> plugins/__init__.py        # eagerly imports plugins.scheduler
  -> plugins.scheduler
  -> apscheduler.schedulers.asyncio   # missing in mcp-server venv
```

## Fix

Adds `apscheduler>=3.11.2,<4` to `mcp-server/pyproject.toml` (the same caret range pinned in `src/cofounder_agent/pyproject.toml`) and regenerates `mcp-server/uv.lock`. Re-architecting `plugins/__init__.py` to defer scheduler imports would be a larger change with cross-cutting risk; bringing the dep in line with the cofounder agent is the minimal, low-risk fix.

## Test plan

- [x] Reproduced the original crash inside the mcp-server venv before the fix
- [x] `uv lock` resolves cleanly (added apscheduler 3.11.2, tzdata, tzlocal)
- [x] `uv sync` installs apscheduler in the mcp-server venv
- [x] `import server` succeeds
- [x] `from plugins.scheduler import PluginScheduler` succeeds in the mcp-server venv (the exact symbol that was failing)
- [ ] Live MCP smoke test against the running worker — `Poindexter:topics_propose(topic="...", source="mcp_test")` returns a JSON result and creates a `pipeline_tasks` row at `awaiting_gate='topic_decision'`

## Acceptance (from issue)

- [x] `mcp-server/uv.lock` regenerated
- [x] Import chain that blocked `topics_propose` resolves cleanly
- [ ] End-to-end `topics_propose` -> `topics_show` -> `topics_approve` against a live worker (operator sweep)