### PR TITLE
feat(health): expose migration drift in /api/health (#230)

### DIFF
--- a/src/cofounder_agent/main.py
+++ b/src/cofounder_agent/main.py
@@ -608,6 +608,54 @@ async def api_health():
         except Exception:
             pass
 
+        # Migration drift detection (#230)
+        # Compares applied (schema_migrations table) vs available (.py files in
+        # services/migrations/) so external monitors can detect schema drift.
+        try:
+            from pathlib import Path
+
+            migrations_dir = Path(__file__).parent / "services" / "migrations"
+            available = sorted(
+                p.name
+                for p in migrations_dir.glob("*.py")
+                if p.name != "__init__.py"
+            )
+
+            pool = getattr(database_service, "pool", None) if database_service else None
+            if pool is None:
+                health_data["components"]["migrations"] = {
+                    "status": "unknown",
+                    "error": "database pool unavailable",
+                }
+            else:
+                async with pool.acquire() as conn:
+                    applied = await conn.fetchval(
+                        "SELECT COUNT(*) FROM schema_migrations"
+                    )
+                    latest_applied = await conn.fetchval(
+                        "SELECT name FROM schema_migrations "
+                        "ORDER BY applied_at DESC LIMIT 1"
+                    )
+                applied = int(applied or 0)
+                pending = max(len(available) - applied, 0)
+                drift = pending > 0
+                health_data["components"]["migrations"] = {
+                    "applied": applied,
+                    "pending": pending,
+                    "latest_applied": latest_applied,
+                    "drift": drift,
+                }
+                if drift and health_data["status"] == "healthy":
+                    health_data["status"] = "degraded"
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                "Migration health check failed in /api/health: %s", str(e), exc_info=True
+            )
+            health_data["components"]["migrations"] = {
+                "status": "unknown",
+                "error": str(e),
+            }
+
         return health_data
     except Exception as e:  # pylint: disable=broad-except
         logger.error("Health check failed: %s", str(e), exc_info=True)


### PR DESCRIPTION
## Summary

Adds a `migrations` block to `/api/health.components` so external monitors (Uptime Kuma, brain probes, Grafana synthetic checks) can detect schema drift the moment the worker is on an older migration set than what's checked into the repo.

```json
"migrations": {
  "applied": 104,
  "pending": 0,
  "latest_applied": "0104_seed_voice_agent_defaults.py",
  "drift": false
}
```

- `applied` — `COUNT(*)` from `schema_migrations`
- `pending` — `*.py` files in `services/migrations/` (excluding `__init__.py`) minus `applied`
- `latest_applied` — most recent `schema_migrations.name` (`ORDER BY applied_at DESC LIMIT 1`)
- `drift` — `pending > 0`

When `drift` is true, overall `status` is bumped to `degraded` so Uptime Kuma trips automatically (per the acceptance criteria in #230).

If the DB pool is unavailable, the block returns `{"status": "unknown", "error": "..."}` rather than 500-ing the whole endpoint.

Single-file change, no behavior change for existing fields.

Re-do of #251 (closed because the wrong workflow leaked 100+ private files). Branch was cut fresh from `github/main` this time.

## Test plan

- [ ] CI green (Mintlify link-rot + spellcheck)
- [ ] Hit `/api/health` on a worker and confirm the new `migrations` block is present and accurate
- [ ] Stop the worker mid-migration sequence (e.g. add a fresh migration file but skip running it) and confirm `drift: true` + status `degraded`

Closes #230