### PR TITLE
ci: smoke-test migrations on a fresh DB (#229)

### DIFF
--- a/.github/workflows/migrations-smoke.yml
+++ b/.github/workflows/migrations-smoke.yml
@@ -1,0 +1,78 @@
+# Smoke-test that every migration in src/cofounder_agent/services/migrations/
+# applies cleanly against an empty Postgres 16 + pgvector database.
+# Catches "migration N silently dropped a column migration M depended on"
+# regressions before they hit a real restart. (GH#229)
+name: migrations-smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/cofounder_agent/services/migrations/**"
+      - "scripts/ci/migrations_smoke.py"
+      - ".github/workflows/migrations-smoke.yml"
+      - "src/cofounder_agent/pyproject.toml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/cofounder_agent/services/migrations/**"
+      - "scripts/ci/migrations_smoke.py"
+      - ".github/workflows/migrations-smoke.yml"
+      - "src/cofounder_agent/pyproject.toml"
+  workflow_dispatch:
+
+jobs:
+  migrations-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: poindexter_test
+        ports:
+          - 5432:5432
+        # Health-check ensures the runner waits until pg_isready before the
+        # job step starts — matches the canonical actions/example pattern.
+        options: >-
+          --health-cmd "pg_isready -U postgres -d poindexter_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/poindexter_test
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The runner only needs asyncpg + the project's own migration files.
+      # Avoid a full poetry install (300+ deps, ~2 min) — keeps this job fast.
+      - name: Install runtime deps
+        run: pip install "asyncpg>=0.30,<0.32"
+
+      - name: Wait for Postgres
+        run: |
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U postgres > /dev/null 2>&1; then
+              echo "postgres ready"
+              exit 0
+            fi
+            echo "waiting for postgres... ($i)"
+            sleep 1
+          done
+          echo "postgres never became ready" >&2
+          exit 1
+
+      - name: Run migrations against empty database
+        run: python scripts/ci/migrations_smoke.py

--- a/scripts/ci/migrations_smoke.py
+++ b/scripts/ci/migrations_smoke.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""CI smoke-test: apply every migration to a fresh database (issue #229).
+
+Spins up an asyncpg pool against ``DATABASE_URL`` (typically a throwaway
+Postgres 16 + pgvector service container in CI), invokes the project's
+``services.migrations.run_migrations`` runner end-to-end, and asserts that
+exactly one ``schema_migrations`` row exists per migration file in
+``src/cofounder_agent/services/migrations/`` (excluding ``__init__.py``).
+
+The runner itself swallows per-migration exceptions and returns ``False``
+when any failed, so we surface that as a non-zero exit. The row-count
+assertion is what actually catches the "migration N silently dropped a
+column migration M depended on" class of bug — the runner records a row
+only on successful apply.
+
+This script is dependency-light by design: it only imports asyncpg plus the
+project's own migration runner. Run it from the repo root:
+
+    DATABASE_URL=postgres://postgres:postgres@localhost:5432/poindexter_test \
+        python scripts/ci/migrations_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "src" / "cofounder_agent"
+MIGRATIONS_DIR = BACKEND_ROOT / "services" / "migrations"
+
+# The migration runner imports ``from services.logger_config import get_logger``
+# (relative to the backend package root), so make that importable before the
+# import of the runner itself.
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.migrations import run_migrations  # noqa: E402
+
+
+class _PoolHolder:
+    """Minimal stand-in for ``DatabaseService`` — the runner only touches ``.pool``."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self.pool = pool
+
+
+def _migration_files() -> list[Path]:
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+async def _run() -> int:
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL must be set", file=sys.stderr)
+        return 2
+
+    files = _migration_files()
+    expected = len(files)
+    print(f"[smoke] discovered {expected} migration file(s) under {MIGRATIONS_DIR}")
+
+    # asyncpg accepts both ``postgres://`` and ``postgresql://`` schemes.
+    pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=4)
+    try:
+        runner_ok = await run_migrations(_PoolHolder(pool))
+
+        async with pool.acquire() as conn:
+            applied_rows = await conn.fetch(
+                "SELECT name FROM schema_migrations ORDER BY name"
+            )
+    finally:
+        await pool.close()
+
+    applied_names = {row["name"] for row in applied_rows}
+    file_names = {f.name for f in files}
+    missing = sorted(file_names - applied_names)
+    extra = sorted(applied_names - file_names)
+
+    print(f"[smoke] runner returned ok={runner_ok}")
+    print(f"[smoke] schema_migrations rows: {len(applied_names)} / files: {expected}")
+
+    failed = False
+    if not runner_ok:
+        print("FAIL: run_migrations() reported one or more failures", file=sys.stderr)
+        failed = True
+    if missing:
+        print(
+            "FAIL: migrations did not record a schema_migrations row:\n  - "
+            + "\n  - ".join(missing),
+            file=sys.stderr,
+        )
+        failed = True
+    if extra:
+        print(
+            "FAIL: schema_migrations contains rows with no matching file:\n  - "
+            + "\n  - ".join(extra),
+            file=sys.stderr,
+        )
+        failed = True
+    if len(applied_names) != expected:
+        print(
+            f"FAIL: expected {expected} schema_migrations rows, got {len(applied_names)}",
+            file=sys.stderr,
+        )
+        failed = True
+
+    if failed:
+        return 1
+
+    print(f"[smoke] OK — all {expected} migrations applied cleanly")
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #229. Re-submission of the previously-closed PR #255 (which was closed because it inadvertently included ~100 unrelated files from a wrong-branch push). This branch was cut from `github/main` directly and contains only the two intended files.

- New `migrations-smoke` GitHub Actions job spins up `pgvector/pgvector:pg16` as a service container, installs only `asyncpg`, and runs the project's own migration runner (`services.migrations.run_migrations`) end-to-end against an empty database.
- Asserts `schema_migrations` row count equals migration `*.py` file count (excluding `__init__.py`) and exits non-zero with named lists on any mismatch — this is what catches "migration N silently dropped a column M depended on" type regressions before they hit a real production restart.
- Path-filtered to fire only on changes to the migrations module, the smoke script, the workflow file itself, or `src/cofounder_agent/pyproject.toml`.

## Files

Exactly two files added:

- `.github/workflows/migrations-smoke.yml` — the workflow (Postgres 16 + pgvector service container, asyncpg-only install)
- `scripts/ci/migrations_smoke.py` — the entry script (asyncpg pool → `_PoolHolder` shim → `run_migrations` → row-count assertion)

## Test plan

- [ ] Workflow triggers on this PR (path filter includes `.github/workflows/migrations-smoke.yml`)
- [ ] Postgres 16 + pgvector service container becomes ready
- [ ] `python scripts/ci/migrations_smoke.py` runs and reports per-file results

## Known pre-existing migration failures

The previous attempt (#255) surfaced ~10 pre-existing migrations that reference columns/tables not yet created at the point they run. Those bugs predate this PR — the smoke test is doing exactly what it was designed to do: exposing them. **Expect this PR's CI run to be red on first execution.** The intent is to land the harness now and file follow-up issues for each broken migration; the harness itself is correct.

If the reviewer confirms only the pre-existing failures show up (and not a new bug introduced by the harness), this is safe to merge with `--admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)