### PR TITLE
feat(qa): code-block density gate for tech-tagged posts (#234)

### DIFF
--- a/src/cofounder_agent/services/content_validator.py
+++ b/src/cofounder_agent/services/content_validator.py
@@ -683,6 +683,232 @@ def _detect_hallucinated_references(
     return issues
 
 
+# ---------------------------------------------------------------------------
+# Code-block density check (GH-234)
+# ---------------------------------------------------------------------------
+#
+# Tech blogs without runnable code feel like surface summaries — "talks
+# about Docker" rather than "shows Docker working." Pure-prose tech posts
+# score worse on EEAT signals because they don't demonstrate first-hand
+# expertise.
+#
+# This rule runs only when the post carries one of the configured tech
+# tags (default: technical, ai, programming, ml, python, javascript,
+# rust, go). It compares the number of fenced code blocks against the
+# post's word count and emits a WARNING — never critical — when either
+# threshold is missed:
+#
+#   (a) at least 1 fenced code block per N words (default N=700), AND
+#   (b) at least P% of non-empty content lines live inside a fenced
+#       code block (default P=20%, only applied to posts > 300 words).
+#
+# Intentionally a soft signal: operators may genuinely write a non-code
+# tech post (architecture overview, postmortem). The warning surfaces in
+# the multi_model_qa critique via the existing programmatic_validator
+# review, which lets the human approver decide whether to override.
+
+# Match an opening fenced code block (``` or ~~~), captured as group 1
+# so we can find the matching closer with the same fence character.
+_FENCE_RE = re.compile(r"^(\s*)(```|~~~)([^\n`~]*)$", re.MULTILINE)
+
+
+def _count_code_blocks_and_lines(content: str) -> tuple[int, int, int]:
+    """Walk ``content`` line-by-line and tally fenced code blocks.
+
+    Returns ``(block_count, code_line_count, total_non_empty_lines)``.
+
+    A "block" is any well-formed ``` ... ``` (or ~~~ ... ~~~) pair. An
+    unterminated fence at EOF still counts as one block because the
+    writer's intent was clear; we'd rather count it than reject the
+    post for malformed markdown alone.
+
+    "Code lines" are non-fence lines that sit between an opening and
+    closing fence — used for the line-ratio sub-check.
+    """
+    if not content:
+        return (0, 0, 0)
+    block_count = 0
+    code_lines = 0
+    total_non_empty = 0
+    in_block = False
+    fence_char: str | None = None
+    for raw in content.split("\n"):
+        stripped = raw.strip()
+        if not stripped:
+            # Blank lines are excluded from the denominator so a heavily
+            # paragraph-padded post doesn't dilute the ratio artificially.
+            continue
+        # Fence detection — must start the line (after optional whitespace)
+        # and use only ``` or ~~~ for the fence itself.
+        is_fence = False
+        if stripped.startswith("```") and set(stripped[:3]) == {"`"}:
+            is_fence = True
+            this_fence = "```"
+        elif stripped.startswith("~~~") and set(stripped[:3]) == {"~"}:
+            is_fence = True
+            this_fence = "~~~"
+        if is_fence:
+            if not in_block:
+                in_block = True
+                fence_char = this_fence
+                block_count += 1
+            elif fence_char == this_fence:
+                in_block = False
+                fence_char = None
+            # Fence lines themselves don't count as code or prose for the
+            # ratio; they're structural punctuation.
+            continue
+        total_non_empty += 1
+        if in_block:
+            code_lines += 1
+    return (block_count, code_lines, total_non_empty)
+
+
+def _strip_code_blocks_for_word_count(content: str) -> str:
+    """Return ``content`` with the inside of every fenced block removed.
+
+    Word count for the density ratio is *prose words only* — counting
+    the words inside a code sample would let a single 200-line code
+    block satisfy the per-700-words threshold trivially.
+    """
+    if not content:
+        return ""
+    out: list[str] = []
+    in_block = False
+    fence_char: str | None = None
+    for raw in content.split("\n"):
+        stripped = raw.strip()
+        is_fence = False
+        if stripped.startswith("```") and set(stripped[:3]) == {"`"}:
+            is_fence = True
+            this_fence = "```"
+        elif stripped.startswith("~~~") and set(stripped[:3]) == {"~"}:
+            is_fence = True
+            this_fence = "~~~"
+        if is_fence:
+            if not in_block:
+                in_block = True
+                fence_char = this_fence
+            elif fence_char == this_fence:
+                in_block = False
+                fence_char = None
+            continue
+        if not in_block:
+            out.append(raw)
+    return "\n".join(out)
+
+
+def _is_tech_post(tags: list[str], topic: str, tech_tags: set[str]) -> bool:
+    """Return True if any tag/topic token matches the configured tech-tag set.
+
+    Matching is lowercase + whitespace/dash/underscore-tolerant so the
+    operator can list ``"ai"`` and still catch tags like ``"AI/ML"``,
+    ``"Artificial-Intelligence"`` (when "artificial intelligence" is on
+    the list), etc. Empty inputs return False.
+    """
+    if not tech_tags:
+        return False
+    haystack: set[str] = set()
+    for source in (*(tags or ()), topic or ""):
+        if not source:
+            continue
+        token = str(source).strip().lower()
+        if not token:
+            continue
+        haystack.add(token)
+        for piece in re.split(r"[\s,/\-_]+", token):
+            piece = piece.strip()
+            if piece:
+                haystack.add(piece)
+    return any(t in haystack for t in tech_tags)
+
+
+def _check_code_block_density(
+    content: str,
+    topic: str,
+    tags: list[str],
+) -> list[ValidationIssue]:
+    """GH-234: warn when tech-tagged posts ship without enough code.
+
+    All thresholds + the tag list are read from ``app_settings`` via
+    ``site_config`` so operators can tune per niche without redeploys.
+    Returns warnings only — never critical.
+    """
+    if not _sc.get_bool("code_density_check_enabled", True):
+        return []
+    tech_tags = {
+        t.strip().lower()
+        for t in _sc.get_list(
+            "code_density_tag_filter",
+            "technical,ai,programming,ml,python,javascript,rust,go",
+        )
+        if t and t.strip()
+    }
+    if not _is_tech_post(tags, topic, tech_tags):
+        return []
+
+    min_blocks_per_700w = _sc.get_int("code_density_min_blocks_per_700w", 1)
+    min_line_ratio_pct = _sc.get_int("code_density_min_line_ratio_pct", 20)
+    long_post_floor_words = _sc.get_int("code_density_long_post_floor_words", 300)
+
+    block_count, code_lines, total_non_empty = _count_code_blocks_and_lines(content)
+    prose_text = _strip_code_blocks_for_word_count(content)
+    word_count = len(re.findall(r"\b[\w'-]+\b", prose_text))
+
+    issues: list[ValidationIssue] = []
+
+    # Sub-check (a): blocks-per-N-words floor. Only meaningful when the
+    # post is long enough that "zero code blocks" is genuinely a signal —
+    # a 200-word note doesn't need a snippet.
+    if (
+        min_blocks_per_700w > 0
+        and word_count >= 200
+    ):
+        # Round up so a 701-word post still requires the floor count.
+        expected_blocks = max(
+            min_blocks_per_700w,
+            -(-word_count * min_blocks_per_700w // 700),
+        )
+        if block_count < expected_blocks:
+            issues.append(ValidationIssue(
+                severity="warning",
+                category="code_block_density",
+                description=(
+                    f"Tech post has {block_count} fenced code block(s) for "
+                    f"{word_count} prose words; expected at least "
+                    f"{expected_blocks} (threshold: "
+                    f"{min_blocks_per_700w} per 700 words). Consider adding "
+                    "a runnable example — pure-prose tech posts hurt EEAT signals."
+                ),
+                matched_text=f"blocks={block_count}, prose_words={word_count}",
+            ))
+
+    # Sub-check (b): code-line ratio floor for longer posts. Independent
+    # of (a) — a post can have one giant block but still flunk this if
+    # the code share is buried under prose.
+    if (
+        min_line_ratio_pct > 0
+        and total_non_empty > 0
+        and word_count >= long_post_floor_words
+    ):
+        ratio_pct = (code_lines * 100) // total_non_empty
+        if ratio_pct < min_line_ratio_pct:
+            issues.append(ValidationIssue(
+                severity="warning",
+                category="code_block_density",
+                description=(
+                    f"Tech post code-line ratio is {ratio_pct}% "
+                    f"({code_lines}/{total_non_empty} non-empty lines); "
+                    f"threshold is {min_line_ratio_pct}%. Add or expand "
+                    "code samples so the post demonstrates the technique, "
+                    "not just describes it."
+                ),
+                matched_text=f"code_lines={code_lines}, total_lines={total_non_empty}",
+            ))
+
+    return issues
+
+
 def validate_content(
     title: str,
     content: str,
@@ -766,6 +992,14 @@ def validate_content(
     # to critical if the same category fires > N times (same plumbing as
     # #91's unlinked_citation path).
     issues.extend(_detect_hallucinated_references(title, content, topic, tags))
+
+    # 5d. Code-block density (GH-234). Soft signal — tech-tagged posts
+    # with too little runnable code get a warning (never critical) so
+    # the human approver in multi_model_qa can decide whether the post
+    # legitimately doesn't need code (architecture overview, postmortem)
+    # or whether the writer surface-summarized a topic that needed
+    # demonstration. Tag list + thresholds are DB-tunable.
+    issues.extend(_check_code_block_density(content, topic, tags))
 
     # 6. Check for brand contradictions (promoting paid cloud APIs)
     issues.extend(_check_patterns(

--- a/src/cofounder_agent/services/migrations/0112_seed_code_density_settings.py
+++ b/src/cofounder_agent/services/migrations/0112_seed_code_density_settings.py
@@ -1,0 +1,128 @@
+"""Migration 0112: seed code-block density quality-gate settings (GH-234).
+
+The content validator now warns when a tech-tagged post lacks enough
+fenced code blocks to actually *demonstrate* the technique it's
+describing. Pure-prose tech posts hurt EEAT signals — readers (and
+ranking systems) treat "talks about Docker" as weaker than "shows
+Docker working." See ``services/content_validator.py`` ::
+``_check_code_block_density``.
+
+This migration seeds the five ``app_settings`` rows that control the
+behavior. All warning-level by design: the operator may legitimately
+ship a non-code tech post (architecture overview, postmortem), so the
+gate flags rather than rejects.
+
+* ``code_density_check_enabled`` — master kill-switch. Default ``true``.
+* ``code_density_tag_filter`` — comma-separated list of tags that
+  qualify a post as "tech" for this rule. Default covers the common
+  developer-content surface (technical, ai, programming, ml, python,
+  javascript, rust, go).
+* ``code_density_min_blocks_per_700w`` — fenced-block floor per 700
+  prose words. Default ``1``.
+* ``code_density_min_line_ratio_pct`` — minimum percentage of non-empty
+  content lines that must live inside a fenced block, applied only to
+  longer posts. Default ``20``.
+* ``code_density_long_post_floor_words`` — word-count threshold below
+  which the line-ratio sub-check is skipped. Default ``300`` per the
+  issue spec ("for posts >300 words").
+
+Idempotent: ``ON CONFLICT DO NOTHING`` leaves any operator-tuned value
+alone. Safe to re-run. Down migration deletes the five rows.
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+_SEED_ROWS = (
+    (
+        "code_density_check_enabled",
+        "true",
+        "content",
+        "GH-234: enable the code-block density quality gate. When true, "
+        "tech-tagged posts that ship without enough fenced code blocks "
+        "emit a (non-blocking) warning during multi_model_qa review.",
+    ),
+    (
+        "code_density_tag_filter",
+        "technical,ai,programming,ml,python,javascript,rust,go",
+        "content",
+        "GH-234: comma-separated list of tag/topic tokens that qualify "
+        "a post as 'tech' for the code-block density rule. Matched "
+        "case-insensitively against post tags + topic. Set to an empty "
+        "string to disable the gate without touching the master flag.",
+    ),
+    (
+        "code_density_min_blocks_per_700w",
+        "1",
+        "content",
+        "GH-234: minimum fenced code blocks expected per 700 prose words "
+        "in a tech post. The check skips posts under 200 prose words "
+        "regardless. Set to 0 to disable just this sub-check.",
+    ),
+    (
+        "code_density_min_line_ratio_pct",
+        "20",
+        "content",
+        "GH-234: minimum percentage of non-empty content lines that "
+        "must live inside a fenced code block, applied only to posts "
+        "above code_density_long_post_floor_words. Set to 0 to disable "
+        "just this sub-check.",
+    ),
+    (
+        "code_density_long_post_floor_words",
+        "300",
+        "content",
+        "GH-234: prose word-count threshold above which the line-ratio "
+        "sub-check kicks in. Per the issue spec, short posts (<300 "
+        "words) don't get the ratio check because a 200-word note "
+        "doesn't need a code-heavy layout to be valuable.",
+    ),
+)
+
+
+async def _table_exists(conn, table: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+            "WHERE table_name = $1)",
+            table,
+        )
+    )
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        if not await _table_exists(conn, "app_settings"):
+            logger.info(
+                "Table 'app_settings' missing — skipping migration 0112"
+            )
+            return
+        for key, value, category, description in _SEED_ROWS:
+            await conn.execute(
+                """
+                INSERT INTO app_settings (
+                    key, value, category, description, is_secret
+                )
+                VALUES ($1, $2, $3, $4, false)
+                ON CONFLICT (key) DO NOTHING
+                """,
+                key, value, category, description,
+            )
+        logger.info(
+            "Migration 0112: seeded %d code-density settings (if not already set)",
+            len(_SEED_ROWS),
+        )
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        keys = [r[0] for r in _SEED_ROWS]
+        await conn.execute(
+            "DELETE FROM app_settings WHERE key = ANY($1)", keys,
+        )
+        logger.info(
+            "Migration 0112 rolled back: removed %d code-density settings",
+            len(keys),
+        )

--- a/src/cofounder_agent/tests/unit/services/test_code_block_density.py
+++ b/src/cofounder_agent/tests/unit/services/test_code_block_density.py
@@ -1,0 +1,290 @@
+"""Unit tests for the code-block density quality gate (GH-234).
+
+Verifies that ``services.content_validator.validate_content`` emits a
+``code_block_density`` warning when:
+
+* The post is tagged with one of the configured tech tags, AND
+* The fenced-code-block density is below the configured threshold.
+
+Also verifies the negative cases — non-tech posts, posts with enough
+code, and the global kill-switch — all skip the gate cleanly.
+
+Tests mutate ``services.site_config.site_config._config`` directly. The
+unit-test conftest snapshots + restores that dict between tests
+(layer 3 of ``tests/unit/conftest.py``), so per-test seeds don't leak.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.content_validator import (
+    _check_code_block_density,
+    _count_code_blocks_and_lines,
+    _is_tech_post,
+    validate_content,
+)
+from services.site_config import site_config
+
+
+# ---------------------------------------------------------------------------
+# Test-local helpers
+# ---------------------------------------------------------------------------
+
+
+_TECH_TAGS_DEFAULT = "technical,ai,programming,ml,python,javascript,rust,go"
+
+
+def _seed_density_settings(
+    *,
+    enabled: bool = True,
+    tag_filter: str = _TECH_TAGS_DEFAULT,
+    min_blocks_per_700w: int = 1,
+    min_line_ratio_pct: int = 20,
+    long_post_floor_words: int = 300,
+) -> None:
+    """Push the GH-234 settings into the site_config singleton.
+
+    The autouse fixture in ``tests/unit/conftest.py`` resets these
+    between tests, so each test starts from a clean baseline.
+    """
+    site_config._config["code_density_check_enabled"] = "true" if enabled else "false"
+    site_config._config["code_density_tag_filter"] = tag_filter
+    site_config._config["code_density_min_blocks_per_700w"] = str(min_blocks_per_700w)
+    site_config._config["code_density_min_line_ratio_pct"] = str(min_line_ratio_pct)
+    site_config._config["code_density_long_post_floor_words"] = str(long_post_floor_words)
+
+
+def _prose_post(word_count: int) -> str:
+    """Generate a prose body of ~word_count words with no code blocks."""
+    sentence = (
+        "Docker provides isolated environments for applications and lets "
+        "you ship reproducible builds with predictable dependencies. "
+    )
+    # ~17 words per sentence — repeat enough to clear the requested target.
+    repeats = max(1, (word_count // 17) + 1)
+    return (sentence * repeats).strip()
+
+
+def _post_with_blocks(prose_words: int, num_blocks: int, lines_per_block: int = 4) -> str:
+    """Build a post with ``num_blocks`` fenced code blocks of given size."""
+    body = _prose_post(prose_words)
+    snippets = []
+    for i in range(num_blocks):
+        snippet_lines = "\n".join(f"print({i!r}, {j})" for j in range(lines_per_block))
+        snippets.append(f"```python\n{snippet_lines}\n```")
+    return body + "\n\n" + "\n\n".join(snippets) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Helper-function-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestCountCodeBlocks:
+    def test_no_blocks(self):
+        blocks, code_lines, total = _count_code_blocks_and_lines("Just prose here.\nMore prose.")
+        assert blocks == 0
+        assert code_lines == 0
+        assert total == 2
+
+    def test_single_well_formed_block(self):
+        content = "Intro line.\n```python\nprint('hi')\nprint('bye')\n```\nOutro."
+        blocks, code_lines, total = _count_code_blocks_and_lines(content)
+        assert blocks == 1
+        assert code_lines == 2
+        assert total == 4  # 'Intro line.', 2 code lines, 'Outro.' — fence lines excluded
+
+    def test_unterminated_fence_still_counts(self):
+        # A writer-intent block at EOF without a closer should still tally.
+        content = "Intro.\n```python\nprint('hi')\n"
+        blocks, _, _ = _count_code_blocks_and_lines(content)
+        assert blocks == 1
+
+    def test_tilde_fence_supported(self):
+        content = "Intro.\n~~~\nls -la\n~~~\nOutro."
+        blocks, code_lines, _ = _count_code_blocks_and_lines(content)
+        assert blocks == 1
+        assert code_lines == 1
+
+    def test_empty_content(self):
+        assert _count_code_blocks_and_lines("") == (0, 0, 0)
+        assert _count_code_blocks_and_lines(None) == (0, 0, 0)  # type: ignore[arg-type]
+
+
+class TestIsTechPost:
+    def test_matches_explicit_tag(self):
+        assert _is_tech_post(["python"], "", {"python", "go"}) is True
+
+    def test_matches_tag_after_split(self):
+        # "ai/ml" should split into "ai" and "ml" and match either token
+        assert _is_tech_post(["AI/ML"], "", {"ai", "go"}) is True
+
+    def test_matches_via_topic_when_no_tags(self):
+        assert _is_tech_post([], "Python performance tips", {"python"}) is True
+
+    def test_no_match_returns_false(self):
+        assert _is_tech_post(["cooking"], "sourdough", {"python", "go"}) is False
+
+    def test_empty_tech_tags_returns_false(self):
+        # Empty tag list disables the gate entirely
+        assert _is_tech_post(["python"], "python", set()) is False
+
+
+# ---------------------------------------------------------------------------
+# Acceptance-criteria tests (issue spec)
+# ---------------------------------------------------------------------------
+
+
+class TestCodeBlockDensityGate:
+    """The four scenarios called out explicitly in the implementation plan."""
+
+    def test_tech_post_with_too_few_blocks_warns(self):
+        _seed_density_settings()
+        # 700-word post with zero code blocks — should emit at least one
+        # code_block_density warning.
+        body = _prose_post(700)
+        result = validate_content(
+            "Why FastAPI Beats Flask for Async Workloads",
+            body,
+            topic="python",
+            tags=["python", "programming"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert density_issues, "Expected a code_block_density warning for prose-only tech post"
+        assert all(i.severity == "warning" for i in density_issues), (
+            "code_block_density must be warning-level only — never critical"
+        )
+
+    def test_tech_post_with_enough_blocks_passes_density_gate(self):
+        _seed_density_settings()
+        # 700 words + 2 code blocks of 12 lines each = enough blocks AND
+        # enough code-line ratio to clear both sub-checks.
+        body = _post_with_blocks(prose_words=700, num_blocks=2, lines_per_block=12)
+        result = validate_content(
+            "Hands-on Async Python with FastAPI",
+            body,
+            topic="python",
+            tags=["python", "programming"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert not density_issues, (
+            "Tech post with sufficient code blocks should not trigger the "
+            f"density gate; got: {[i.description for i in density_issues]}"
+        )
+
+    def test_non_tech_post_skips_gate_regardless_of_code(self):
+        _seed_density_settings()
+        # Long prose-only post tagged with a non-tech topic — gate must
+        # not fire even though density is technically zero.
+        body = _prose_post(800)
+        result = validate_content(
+            "How to Brew the Perfect Cup of Pour-Over Coffee",
+            body,
+            topic="cooking",
+            tags=["coffee", "lifestyle"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert not density_issues, (
+            "Non-tech post must not trigger code_block_density warning"
+        )
+
+    def test_kill_switch_disables_gate(self):
+        _seed_density_settings(enabled=False)
+        body = _prose_post(900)
+        result = validate_content(
+            "Why FastAPI Beats Flask for Async Workloads",
+            body,
+            topic="python",
+            tags=["python", "programming"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert not density_issues, (
+            "code_density_check_enabled=false must disable the gate"
+        )
+
+
+class TestDensityGateEdgeCases:
+    """Boundary conditions that aren't strictly in the four-bullet plan
+    but are easy to break and would erode trust in the gate."""
+
+    def test_short_tech_post_skips_blocks_subcheck(self):
+        # Posts under 200 prose words shouldn't trip the per-700w floor —
+        # a 50-word note doesn't need a snippet.
+        _seed_density_settings()
+        body = _prose_post(50)
+        result = validate_content(
+            "Quick Python tip",
+            body,
+            topic="python",
+            tags=["python"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert not density_issues
+
+    def test_short_post_skips_line_ratio_subcheck(self):
+        # The line-ratio sub-check is gated on
+        # ``code_density_long_post_floor_words`` (default 300). A 250-word
+        # post with no code should NOT trigger the ratio warning, only
+        # potentially the blocks-per-700w warning (which kicks in at 200).
+        _seed_density_settings()
+        body = _prose_post(250)
+        result = validate_content(
+            "FastAPI quickstart",
+            body,
+            topic="python",
+            tags=["python"],
+        )
+        ratio_issues = [
+            i for i in result.issues
+            if i.category == "code_block_density"
+            and "ratio" in i.description.lower()
+        ]
+        assert not ratio_issues, (
+            "Line-ratio sub-check must skip posts under "
+            "code_density_long_post_floor_words"
+        )
+
+    def test_empty_tag_filter_disables_gate(self):
+        # Operator can soft-disable by emptying the tag list without
+        # touching the master flag.
+        _seed_density_settings(tag_filter="")
+        body = _prose_post(800)
+        result = validate_content(
+            "Distributed Systems Patterns",
+            body,
+            topic="python",
+            tags=["python"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert not density_issues
+
+    def test_helper_returns_empty_list_when_disabled(self):
+        # Belt-and-suspenders: the internal helper itself must short-circuit
+        # so callers that bypass validate_content() still get correct behavior.
+        _seed_density_settings(enabled=False)
+        issues = _check_code_block_density(
+            _prose_post(800), "python", ["python"]
+        )
+        assert issues == []
+
+    def test_density_warning_never_blocks_post(self):
+        # Re-asserts the spec's "warning, not hard veto" guarantee: a
+        # density warning alone must not cause result.passed to flip to
+        # False. (Other rules can still fail the post for other reasons.)
+        _seed_density_settings()
+        body = _prose_post(800)
+        result = validate_content(
+            "Distributed Systems Patterns",
+            body,
+            topic="python",
+            tags=["python"],
+        )
+        density_issues = [i for i in result.issues if i.category == "code_block_density"]
+        assert density_issues, "Sanity: should have triggered the gate"
+        # passed depends on whether OTHER rules fired — but density alone
+        # is warning-level, so density warnings shouldn't drive critical_count.
+        density_critical = [
+            i for i in density_issues if i.severity == "critical"
+        ]
+        assert not density_critical


### PR DESCRIPTION
## Summary

Resolves #234. Adds a soft (warning-only) quality rule to `services/content_validator.py` that flags tech-tagged posts shipping without enough fenced code blocks to actually demonstrate the technique they describe.

Two independent sub-checks fire under one `code_block_density` category:

- **Blocks-per-700-prose-words floor** (default: at least 1 per 700w), skipped for posts under 200 prose words.
- **Code-line ratio** across non-empty content lines (default 20%), skipped for posts under `code_density_long_post_floor_words` (default 300, per the issue spec).

The gate is intentionally **warning-level only** — operators may legitimately ship a non-code tech post (architecture overview, postmortem) — so the warning surfaces in the `multi_model_qa` `programmatic_validator` review and the human approver decides whether to override.

Migration `0112_seed_code_density_settings.py` seeds five DB-tunable `app_settings` (idempotent, `ON CONFLICT DO NOTHING`):

| Setting | Default |
| --- | --- |
| `code_density_check_enabled` | `true` |
| `code_density_tag_filter` | `technical,ai,programming,ml,python,javascript,rust,go` |
| `code_density_min_blocks_per_700w` | `1` |
| `code_density_min_line_ratio_pct` | `20` |
| `code_density_long_post_floor_words` | `300` |

## Files touched (3)

- `src/cofounder_agent/services/content_validator.py` — new helper + wired into `validate_content`
- `src/cofounder_agent/services/migrations/0112_seed_code_density_settings.py` — DB seed
- `src/cofounder_agent/tests/unit/services/test_code_block_density.py` — 19 new tests

## Test plan

- [x] `pytest tests/unit/services/test_code_block_density.py` — 19 passed
- [x] `pytest tests/unit/services/test_content_validator.py` — 100 passed (no regressions)
- [x] Acceptance scenarios from the issue:
  - [x] Tech-tagged post with too-few code blocks → emits `code_block_density` warning
  - [x] Tech-tagged post with enough code blocks → gate is silent
  - [x] Non-tech post → gate is skipped regardless of code density
  - [x] Master kill-switch off → gate is skipped
  - [x] Density warning never promotes to critical (warning-only guarantee)