### PR TITLE
feat(topics): move _NEWS_PATTERNS + CATEGORY_SEARCHES to app_settings (#218)

### DIFF
--- a/src/cofounder_agent/services/migrations/0111_seed_topic_discovery_filters.py
+++ b/src/cofounder_agent/services/migrations/0111_seed_topic_discovery_filters.py
@@ -1,0 +1,107 @@
+"""Migration 0111: Seed empty defaults for topic_discovery filter constants.
+
+Pairs with ``services/topic_discovery.py`` (gh#218). The dispatcher used
+to bake two niche-coloured filter constants directly into Python:
+
+- ``_NEWS_PATTERNS`` — regex list that flags titles as "news/junk" and
+  rejects them. Encodes Glad Labs's evergreen-tech-editorial voice. A
+  real-estate niche customer would *want* the lawsuit/court patterns to
+  pass through; a fashion niche would *want* merch/sticker/sale matches.
+- ``CATEGORY_SEARCHES`` — category -> keyword-query map used by
+  ``_classify_category``. Defaults every miss to ``"technology"``, so a
+  non-tech niche gets every topic mis-classified.
+
+After this migration both move to ``app_settings`` with **empty defaults**
+(``[]`` and ``{}``) — Poindexter ships niche-agnostic out of the box.
+The hardcoded constants stay in code as a permissive fallback for the
+existing Glad Labs deployment, so behaviour doesn't change unless an
+operator explicitly opts in.
+
+Storage format:
+
+- ``topic_discovery_news_patterns`` — JSON array of regex strings
+  (case-insensitive at runtime). Example::
+
+      ["\\b(?:lawsuit|sued|court)\\b", "\\b(?:shirt|merch|sticker)\\b"]
+
+- ``topic_discovery_category_searches`` — JSON object mapping category
+  name -> list of keyword search strings. Example::
+
+      {
+          "technology": ["latest AI tools 2026", "new frameworks"],
+          "gardening":  ["heirloom tomato varieties", "compost tea"]
+      }
+
+Idempotent: ``ON CONFLICT (key) DO NOTHING`` — a customer who has
+already seeded their own niche values keeps them through migration
+re-runs.
+
+Related: #216 (brand_keywords), #217 (industry-specific seed scripts).
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+_SEEDS: list[tuple[str, str, str]] = [
+    (
+        "topic_discovery_news_patterns",
+        "[]",
+        "JSON array of regex strings (case-insensitive). When non-empty, "
+        "TopicDiscovery uses these patterns to reject titles as "
+        "news/junk/merch/etc. instead of the hardcoded Glad Labs set "
+        "(lawsuit/court, election/senator, shirt/merch, etc.). Empty "
+        "array falls back to the hardcoded set for backwards "
+        "compatibility. Customers running Poindexter for a niche where "
+        "those topics are on-brand (real estate, fashion, politics) "
+        "should set this to their own array — including '[]' to disable "
+        "regex-based junk filtering entirely. Only the regex-based "
+        "filter is overridden; the too-short-title guard still applies "
+        "unconditionally.",
+    ),
+    (
+        "topic_discovery_category_searches",
+        "{}",
+        "JSON object mapping category name -> list of keyword search "
+        "strings. Used by TopicDiscovery._classify_category to bucket a "
+        "scraped title into a category, and by web-search topic sources "
+        "to issue DuckDuckGo queries per category. Empty object falls "
+        "back to the hardcoded Glad Labs categories (technology / "
+        "startup / security / engineering / insights / business / "
+        "hardware / gaming) for backwards compatibility. Customers in a "
+        "different niche should set this to their own category map so "
+        "classification doesn't default everything to 'technology'.",
+    ),
+]
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        inserted = 0
+        for key, value, description in _SEEDS:
+            result = await conn.execute(
+                """
+                INSERT INTO app_settings (key, value, description, is_active)
+                VALUES ($1, $2, $3, TRUE)
+                ON CONFLICT (key) DO NOTHING
+                """,
+                key, value, description,
+            )
+            if result == "INSERT 0 1":
+                inserted += 1
+        logger.info(
+            "0111: seeded %d/%d topic_discovery filter settings "
+            "(remaining were already set)",
+            inserted, len(_SEEDS),
+        )
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        for key, _value, _description in _SEEDS:
+            await conn.execute(
+                "DELETE FROM app_settings WHERE key = $1",
+                key,
+            )
+        logger.info("0111: removed %d topic_discovery filter seeds", len(_SEEDS))

--- a/src/cofounder_agent/services/migrations/0111_seed_topic_discovery_filters.py
+++ b/src/cofounder_agent/services/migrations/0111_seed_topic_discovery_filters.py
@@ -82,8 +82,8 @@ async def up(pool) -> None:
         for key, value, description in _SEEDS:
             result = await conn.execute(
                 """
-                INSERT INTO app_settings (key, value, description, is_active)
-                VALUES ($1, $2, $3, TRUE)
+                INSERT INTO app_settings (key, value, category, description, is_secret)
+                VALUES ($1, $2, 'content', $3, FALSE)
                 ON CONFLICT (key) DO NOTHING
                 """,
                 key, value, description,

--- a/src/cofounder_agent/services/topic_discovery.py
+++ b/src/cofounder_agent/services/topic_discovery.py
@@ -26,7 +26,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from services.logger_config import get_logger
-from services.site_config import site_config
+from services.site_config import site_config as _module_site_config
+
+# Re-export the module-level singleton under the legacy ``site_config``
+# name so existing call sites in this file (which still read directly
+# from the singleton) keep working unchanged. Aliased rather than
+# re-imported so there's a single hook point if/when the singleton is
+# retired (Phase H — gh#95).
+site_config = _module_site_config
 
 logger = get_logger(__name__)
 
@@ -127,8 +134,30 @@ def _word_overlap_match(
 class TopicDiscovery:
     """Discover trending topics from free web sources."""
 
-    def __init__(self, pool):
+    def __init__(self, pool, *, site_config: Any = None):
+        """Initialize the topic discovery dispatcher.
+
+        Args:
+            pool: asyncpg pool for reading published posts / app_settings.
+            site_config: Optional SiteConfig instance (keyword-only).
+                When ``None``, falls back to the module-level singleton
+                imported at the top of this file. Tests can pass an
+                explicit instance built via
+                ``SiteConfig(initial_config={...})`` for isolation.
+        """
         self.pool = pool
+        # Phase H groundwork: prefer a DI'd SiteConfig when callers
+        # supply one, fall back to the module singleton so existing
+        # ``TopicDiscovery(pool)`` callers keep working unchanged.
+        self._site_config = (
+            site_config if site_config is not None else _module_site_config
+        )
+        # Cached resolved overrides for the DB-backed filter constants
+        # (gh#218). Resolved lazily on first use so construction stays
+        # cheap and tests don't have to seed these settings to spin up
+        # an instance. ``None`` means "not yet resolved".
+        self.__news_re_cache: list[re.Pattern[str]] | None = None
+        self.__category_searches_cache: dict[str, list[str]] | None = None
 
     async def discover(self, max_topics: int = 10, categories: list[str] | None = None) -> list[DiscoveredTopic]:
         """Discover fresh topics from multiple sources.
@@ -620,18 +649,88 @@ class TopicDiscovery:
                 return True
         return False
 
+    def _resolved_category_searches(self) -> dict[str, list[str]]:
+        """Resolve the active category-search map (gh#218).
+
+        Resolution order:
+
+        1. ``app_settings.topic_discovery_category_searches`` — JSON
+           object, the customer-tunable override. Empty object ``{}``
+           (the default after migration 0111) means "no override".
+        2. The module-level :pydata:`CATEGORY_SEARCHES` map — Glad
+           Labs's tech / startup / hardware / gaming buckets, used as a
+           permissive fallback so existing deployments don't change
+           behaviour out from under themselves.
+
+        Cached on ``self`` after the first call: ``site_config.get`` is
+        a cheap dict lookup but ``json.loads`` is wasted work to repeat
+        on every classification.
+        """
+        if self.__category_searches_cache is not None:
+            return self.__category_searches_cache
+        raw = (
+            self._site_config.get("topic_discovery_category_searches", "")
+            or ""
+        ).strip()
+        resolved: dict[str, list[str]] = {}
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    resolved = {
+                        str(cat): [str(q) for q in queries]
+                        for cat, queries in parsed.items()
+                        if isinstance(queries, list)
+                    }
+                else:
+                    logger.warning(
+                        "[TOPIC_DISCOVERY] topic_discovery_category_searches "
+                        "is not a JSON object (got %s); using hardcoded "
+                        "CATEGORY_SEARCHES fallback",
+                        type(parsed).__name__,
+                    )
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.warning(
+                    "[TOPIC_DISCOVERY] Failed to parse "
+                    "topic_discovery_category_searches as JSON: %s; "
+                    "using hardcoded CATEGORY_SEARCHES fallback", e,
+                )
+        else:
+            # Empty string OR setting absent. Migration 0111 seeds "{}",
+            # so a totally missing key is a strong signal the migration
+            # hasn't been applied yet — log loudly per the gh#218 brief.
+            try:
+                _all_keys = self._site_config.all()
+            except Exception:
+                _all_keys = {}
+            if "topic_discovery_category_searches" not in _all_keys:
+                logger.warning(
+                    "[TOPIC_DISCOVERY] topic_discovery_category_searches "
+                    "not seeded — migration 0111 hasn't run? Falling "
+                    "back to hardcoded CATEGORY_SEARCHES."
+                )
+        if not resolved:
+            resolved = CATEGORY_SEARCHES
+        self.__category_searches_cache = resolved
+        return resolved
+
     def _classify_category(self, title: str) -> str:
         """Classify a title into a category."""
         title_lower = title.lower()
         scores = {}
-        for cat, searches in CATEGORY_SEARCHES.items():
+        for cat, searches in self._resolved_category_searches().items():
             keywords = " ".join(searches).lower().split()
             score = sum(1 for kw in keywords if kw in title_lower)
             scores[cat] = score
         best = max(scores, key=scores.get) if scores else "technology"
         return best if scores.get(best, 0) > 0 else "technology"
 
-    # Patterns that indicate news/current events (not evergreen editorial content)
+    # Patterns that indicate news/current events (not evergreen editorial
+    # content). Kept as class-level constants for the back-compat
+    # fallback path: when ``app_settings.topic_discovery_news_patterns``
+    # is empty (the default after migration 0111), TopicDiscovery uses
+    # these so existing Glad Labs deployments don't change behaviour.
+    # New customers seed their own JSON-array override per gh#218.
     _NEWS_PATTERNS = [
         r"\b(?:police|arrest|charged|sentenced|indicted|convicted|alleged)\b",
         r"\b(?:lawsuit|sued|court|judge|ruling|verdict)\b",
@@ -643,10 +742,82 @@ class TopicDiscovery:
     ]
     _NEWS_RE = [re.compile(p, re.IGNORECASE) for p in _NEWS_PATTERNS]
 
-    @staticmethod
-    def _is_news_or_junk(title: str) -> bool:
-        """Reject breaking news, current events, personal anecdotes, and merch."""
-        for pattern in TopicDiscovery._NEWS_RE:
+    def _resolved_news_re(self) -> list[re.Pattern[str]]:
+        """Resolve the active news/junk regex list (gh#218).
+
+        Resolution order:
+
+        1. ``app_settings.topic_discovery_news_patterns`` — JSON array
+           of regex strings, customer-tunable override. Empty array
+           ``[]`` (the default after migration 0111) means "no
+           override".
+        2. The class-level :pyattr:`_NEWS_RE` — Glad Labs's
+           lawsuit/election/merch reject list, used as a permissive
+           fallback.
+
+        Compiled patterns are cached on ``self``. Bad regexes in the
+        override are logged and skipped, not raised — one typo in the
+        operator's seed shouldn't take topic discovery offline.
+        """
+        if self.__news_re_cache is not None:
+            return self.__news_re_cache
+        raw = (
+            self._site_config.get("topic_discovery_news_patterns", "")
+            or ""
+        ).strip()
+        compiled: list[re.Pattern[str]] = []
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, list):
+                    for p in parsed:
+                        if not isinstance(p, str):
+                            continue
+                        try:
+                            compiled.append(re.compile(p, re.IGNORECASE))
+                        except re.error as e:
+                            logger.warning(
+                                "[TOPIC_DISCOVERY] Skipping invalid regex "
+                                "in topic_discovery_news_patterns: %r (%s)",
+                                p, e,
+                            )
+                else:
+                    logger.warning(
+                        "[TOPIC_DISCOVERY] topic_discovery_news_patterns "
+                        "is not a JSON array (got %s); using hardcoded "
+                        "_NEWS_RE fallback",
+                        type(parsed).__name__,
+                    )
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.warning(
+                    "[TOPIC_DISCOVERY] Failed to parse "
+                    "topic_discovery_news_patterns as JSON: %s; "
+                    "using hardcoded _NEWS_RE fallback", e,
+                )
+        else:
+            try:
+                _all_keys = self._site_config.all()
+            except Exception:
+                _all_keys = {}
+            if "topic_discovery_news_patterns" not in _all_keys:
+                logger.warning(
+                    "[TOPIC_DISCOVERY] topic_discovery_news_patterns "
+                    "not seeded — migration 0111 hasn't run? Falling "
+                    "back to hardcoded _NEWS_RE."
+                )
+        if not compiled:
+            compiled = self._NEWS_RE
+        self.__news_re_cache = compiled
+        return compiled
+
+    def _is_news_or_junk(self, title: str) -> bool:
+        """Reject breaking news, current events, personal anecdotes, and merch.
+
+        Regex list is sourced from ``app_settings`` (gh#218) with the
+        class-level :pyattr:`_NEWS_RE` as the permissive fallback. The
+        too-short-title guard still applies unconditionally.
+        """
+        for pattern in self._resolved_news_re():
             if pattern.search(title):
                 return True
         # Too short to be a real topic

--- a/src/cofounder_agent/tests/unit/services/test_topic_discovery.py
+++ b/src/cofounder_agent/tests/unit/services/test_topic_discovery.py
@@ -402,31 +402,156 @@ class TestCategorySearches:
 
 
 class TestIsNewsOrJunk:
+    # gh#218: _is_news_or_junk is an instance method now (was @staticmethod)
+    # so the regex list can be sourced from app_settings via SiteConfig.
+    # Each test instantiates a TopicDiscovery — the kwargless ctor falls back
+    # to the module singleton, which in tests is unloaded so we get the
+    # hardcoded _NEWS_RE fallback path.
+
+    def _d(self):
+        return TopicDiscovery(AsyncMock())
+
     def test_too_short_title_rejected(self):
-        assert TopicDiscovery._is_news_or_junk("Short title") is True
-        assert TopicDiscovery._is_news_or_junk("AI Tools") is True
+        d = self._d()
+        assert d._is_news_or_junk("Short title") is True
+        assert d._is_news_or_junk("AI Tools") is True
 
     def test_long_title_not_rejected_for_length(self):
-        assert TopicDiscovery._is_news_or_junk(
+        assert self._d()._is_news_or_junk(
             "Building Production-Ready Microservices with Go"
         ) is False
 
     def test_lawsuit_pattern_rejected(self):
         # Real pattern from _NEWS_PATTERNS — "lawsuit" matches
-        assert TopicDiscovery._is_news_or_junk(
+        assert self._d()._is_news_or_junk(
             "Tech Giant Faces Major Lawsuit Over Privacy"
         ) is True
 
     def test_personal_anecdote_pattern_rejected(self):
         # "my experience" is in the news/junk pattern list
-        assert TopicDiscovery._is_news_or_junk(
+        assert self._d()._is_news_or_junk(
             "My experience building a startup from scratch"
         ) is True
 
     def test_merch_pattern_rejected(self):
-        assert TopicDiscovery._is_news_or_junk(
+        assert self._d()._is_news_or_junk(
             "Limited Edition Tech Merch and Sticker Pack"
         ) is True
+
+
+# ===========================================================================
+# gh#218 — DB-backed filter overrides (_resolved_news_re,
+# _resolved_category_searches)
+# ===========================================================================
+
+
+class _FakeSiteConfig:
+    """Minimal SiteConfig stand-in for gh#218 override tests.
+
+    Only exposes the surface ``TopicDiscovery._resolved_*`` calls reach
+    for: ``get(key, default)`` and ``all()``. Avoids importing the real
+    ``SiteConfig`` class so tests stay decoupled from any Phase H churn
+    on github/main.
+    """
+
+    def __init__(self, values: dict[str, str] | None = None):
+        self._values = values or {}
+
+    def get(self, key: str, default: str = "") -> str:
+        return self._values.get(key, default)
+
+    def all(self) -> dict[str, str]:
+        return dict(self._values)
+
+
+class TestResolvedCategorySearches:
+    def test_empty_falls_back_to_hardcoded(self):
+        sc = _FakeSiteConfig({"topic_discovery_category_searches": "{}"})
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        # Empty JSON object -> hardcoded CATEGORY_SEARCHES fallback
+        assert d._resolved_category_searches() is CATEGORY_SEARCHES
+
+    def test_json_override_used(self):
+        sc = _FakeSiteConfig({
+            "topic_discovery_category_searches":
+                '{"gardening": ["heirloom tomato varieties", "compost tea"]}',
+        })
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        resolved = d._resolved_category_searches()
+        assert "gardening" in resolved
+        assert resolved["gardening"] == ["heirloom tomato varieties", "compost tea"]
+        # Override replaces, doesn't merge
+        assert "technology" not in resolved
+
+    def test_malformed_json_falls_back(self):
+        sc = _FakeSiteConfig({
+            "topic_discovery_category_searches": "{not valid json",
+        })
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        # Bad JSON -> hardcoded fallback, no exception raised
+        assert d._resolved_category_searches() is CATEGORY_SEARCHES
+
+    def test_result_cached_on_instance(self):
+        sc = _FakeSiteConfig({"topic_discovery_category_searches": "{}"})
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        first = d._resolved_category_searches()
+        second = d._resolved_category_searches()
+        assert first is second  # cached, not re-parsed
+
+
+class TestResolvedNewsRe:
+    def test_empty_falls_back_to_hardcoded(self):
+        sc = _FakeSiteConfig({"topic_discovery_news_patterns": "[]"})
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        # Empty array -> hardcoded _NEWS_RE fallback
+        assert d._resolved_news_re() is TopicDiscovery._NEWS_RE
+
+    def test_json_override_used(self):
+        sc = _FakeSiteConfig({
+            "topic_discovery_news_patterns":
+                r'["\\b(?:foo|bar)\\b"]',
+        })
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        compiled = d._resolved_news_re()
+        # Operator's pattern, not the Glad Labs lawsuit/election set
+        assert len(compiled) == 1
+        assert compiled[0].search("things about foo here")
+
+    def test_invalid_regex_skipped(self):
+        # One bad pattern shouldn't break the rest — and shouldn't raise.
+        sc = _FakeSiteConfig({
+            "topic_discovery_news_patterns":
+                r'["[unclosed", "\\b(?:keepme)\\b"]',
+        })
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        compiled = d._resolved_news_re()
+        assert len(compiled) == 1
+        assert compiled[0].search("we should keepme out")
+
+    def test_malformed_json_falls_back(self):
+        sc = _FakeSiteConfig({
+            "topic_discovery_news_patterns": "[not valid json",
+        })
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        assert d._resolved_news_re() is TopicDiscovery._NEWS_RE
+
+    def test_override_changes_is_news_or_junk_behaviour(self):
+        # With an empty override, lawsuit titles still get rejected
+        sc = _FakeSiteConfig({"topic_discovery_news_patterns": "[]"})
+        d = TopicDiscovery(AsyncMock(), site_config=sc)
+        assert d._is_news_or_junk(
+            "Tech Giant Faces Major Lawsuit Over Privacy"
+        ) is True
+
+        # With a custom override that doesn't include "lawsuit",
+        # the same title should pass (real-estate/legal niche)
+        sc2 = _FakeSiteConfig({
+            "topic_discovery_news_patterns": r'["\\b(?:onlything)\\b"]',
+        })
+        d2 = TopicDiscovery(AsyncMock(), site_config=sc2)
+        assert d2._is_news_or_junk(
+            "Tech Giant Faces Major Lawsuit Over Privacy"
+        ) is False
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #218.

## Summary

Two more class-level constants in `services/topic_discovery.py` were baked
into Python and encoded Glad Labs's evergreen-tech-editorial voice as
universal truth:

- `_NEWS_PATTERNS` — regex list that rejects lawsuit/election/merch
  titles. A real-estate or fashion niche customer would WANT those
  topics through.
- `CATEGORY_SEARCHES` — buckets titles into tech / startup / hardware /
  gaming. A non-tech niche gets every topic mis-classified as
  `"technology"`.

Both now read from `app_settings` via `SiteConfig`:

- `topic_discovery_news_patterns` — JSON array of regex strings
- `topic_discovery_category_searches` — JSON object: category -> queries

## Design

Both ship with **empty defaults** (`[]` and `{}`) seeded by migration
`0111_seed_topic_discovery_filters.py`, following the `brand_keywords` /
migration `0105` precedent: an empty value falls back to the hardcoded
Glad Labs set so existing deployments don't change behaviour, and
customers must explicitly opt in to override.

`_resolved_news_re()` and `_resolved_category_searches()` are lazy and
cached per `TopicDiscovery` instance — repeated classification calls
don't re-parse JSON. Bad regexes / malformed JSON are logged and the
dispatcher falls back to the hardcoded list rather than going offline.

`_is_news_or_junk` converts from `@staticmethod` to instance method
(the DB-backed override has to come from `self._site_config`). The
too-short-title guard still applies unconditionally.

`TopicDiscovery.__init__` now accepts an optional `site_config` kwarg
so tests (and Phase H call sites) can inject their own SiteConfig.
When omitted it falls back to the module-level singleton, so existing
`TopicDiscovery(pool)` callers keep working unchanged.

## Files

- `src/cofounder_agent/services/topic_discovery.py` — add ctor kwarg, two `_resolved_*` resolvers, instance `_is_news_or_junk`
- `src/cofounder_agent/services/migrations/0111_seed_topic_discovery_filters.py` — new migration seeding `[]` / `{}` defaults
- `src/cofounder_agent/tests/unit/services/test_topic_discovery.py` — convert `_is_news_or_junk` calls to instance, add 9 new tests covering JSON override, fallback, malformed JSON, invalid-regex skipping, and per-instance caching

## Test plan

- [x] `pytest tests/unit/services/test_topic_discovery.py::TestIsNewsOrJunk` — 5 passed (existing tests, now instance-method)
- [x] `pytest tests/unit/services/test_topic_discovery.py::TestResolvedCategorySearches` — 4 passed (new)
- [x] `pytest tests/unit/services/test_topic_discovery.py::TestResolvedNewsRe` — 5 passed (new)
- [ ] CI green
- [ ] Mintlify build

Related: #216 (brand_keywords), #217 (industry-specific seed scripts).

Replaces closed PR #257 (which was rejected for leaking 100+ unrelated files).