### PR TITLE
feat: niche-aware topic discovery + RAG writer pivot

### DIFF
--- a/docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md
+++ b/docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md
@@ -1,0 +1,2875 @@
+# RAG Pivot + Niche-Aware Topic Discovery — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single-topic approve/reject pipeline entry point with a niche-aware, ranked-batch operator surface, and pivot the writer stage to RAG over internal Glad Labs context.
+
+**Architecture:** Hybrid migration — `services/topic_discovery.py` and `services/topic_dedup*.py` stay; `services/topic_proposal_service.py` is replaced by a new `services/topic_batch_service.py` that orchestrates per-niche discovery → embedding+LLM hybrid ranking → batch creation → operator interaction (CLI + MCP) → handoff into the existing pipeline. Writer stage gets a per-niche `writer_rag_mode` switch with four implementations; Glad Labs uses `TWO_PASS` (internal-context first draft, external fact-augmentation second pass). The existing `topic_decision` approval gate is light-reused as the pause/release control; new MCP/CLI tools mutate the batch row.
+
+**Tech Stack:** Python 3.12, asyncpg, FastAPI, Pipecat (unrelated, just present), pgvector for embeddings, glm-4.7-5090 via Ollama, MCP SDK, click for CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md`
+
+---
+
+## Pre-flight
+
+Before starting Task 1, the implementer should:
+
+1. Read the spec (linked above) cover-to-cover.
+2. Read `src/cofounder_agent/CLAUDE.md` (or top-level `CLAUDE.md`) — covers configuration conventions (`SiteConfig`, `app_settings`, async-everywhere, fail-loud).
+3. `ls src/cofounder_agent/services/migrations/` and pick the next-available migration number (NEXT_MIGRATION). Use that for Task 1 and increment for Task 18.
+4. Confirm working tree is clean and on a fresh branch cut from `github/main` (per the workflow guard documented in CLAUDE.md and the closed PRs #251/#254/#255/#257 — pushing gitea-side branches to github leaks private files).
+
+```bash
+git fetch github
+git checkout -b feat/niche-topic-discovery github/main
+ls src/cofounder_agent/services/migrations/ | tail -3
+# next number = highest + 1, zero-padded to 4 digits
+```
+
+5. Confirm pgvector extension is loaded (`SELECT extname FROM pg_extension WHERE extname='vector'`). Migration 0103 added it; should already be present.
+
+---
+
+## File structure
+
+**New files:**
+
+| Path                                                                                 | Purpose                                                                                                                                 |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/cofounder_agent/services/migrations/<N>_create_niche_topic_discovery_tables.py` | Schema for `niches`, `niche_goals`, `niche_sources`, `topic_batches`, `topic_candidates`, `internal_topic_candidates`, `discovery_runs` |
+| `src/cofounder_agent/services/migrations/<N+1>_seed_glad_labs_niche.py`              | First-niche seed                                                                                                                        |
+| `src/cofounder_agent/services/niche_service.py`                                      | CRUD on `niches` + `niche_goals` + `niche_sources`                                                                                      |
+| `src/cofounder_agent/services/topic_ranking.py`                                      | Goal vectors, embedding pre-rank, LLM final-score, decay re-rank                                                                        |
+| `src/cofounder_agent/services/internal_rag_source.py`                                | Generates internal candidates from `embeddings` table per `source_kind`                                                                 |
+| `src/cofounder_agent/services/topic_batch_service.py`                                | Orchestrator: discovery → rank → batch → resolve → handoff                                                                              |
+| `src/cofounder_agent/services/writer_rag_modes/__init__.py`                          | Mode dispatcher                                                                                                                         |
+| `src/cofounder_agent/services/writer_rag_modes/topic_only.py`                        | TOPIC_ONLY mode                                                                                                                         |
+| `src/cofounder_agent/services/writer_rag_modes/citation_budget.py`                   | CITATION_BUDGET mode                                                                                                                    |
+| `src/cofounder_agent/services/writer_rag_modes/story_spine.py`                       | STORY_SPINE mode                                                                                                                        |
+| `src/cofounder_agent/services/writer_rag_modes/two_pass.py`                          | TWO_PASS mode (Glad Labs default)                                                                                                       |
+| `src/cofounder_agent/tests/unit/services/test_niche_service.py`                      |                                                                                                                                         |
+| `src/cofounder_agent/tests/unit/services/test_topic_ranking.py`                      |                                                                                                                                         |
+| `src/cofounder_agent/tests/unit/services/test_internal_rag_source.py`                |                                                                                                                                         |
+| `src/cofounder_agent/tests/unit/services/test_topic_batch_service.py`                |                                                                                                                                         |
+| `src/cofounder_agent/tests/unit/services/writer_rag_modes/test_modes.py`             |                                                                                                                                         |
+| `src/cofounder_agent/tests/integration/test_niche_discovery_e2e.py`                  |                                                                                                                                         |
+
+**Modified files:**
+
+| Path                                                     | Change                                                                                           |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `src/cofounder_agent/poindexter/cli/topics.py`           | Add `show-batch`, `rank-batch`, `edit-winner`, `resolve-batch`, `reject-batch`, `niche` subgroup |
+| `src/cofounder_agent/services/ai_content_generator.py`   | Add `writer_rag_mode` dispatch in the writer entry point                                         |
+| `src/cofounder_agent/services/topic_proposal_service.py` | Mark deprecated; redirect callers to `topic_batch_service`; final delete in a follow-up PR       |
+| `mcp-server/server.py`                                   | Add MCP tools mirroring the new CLI commands                                                     |
+
+---
+
+## Task 1: Schema migration — niche topic-discovery tables
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/migrations/<NEXT_MIGRATION>_create_niche_topic_discovery_tables.py`
+
+- [ ] **Step 1: Write the failing migration smoke test invocation**
+
+The repo has a CI job `migrations-smoke` (added in #229 / PR #272) that asserts every migration applies cleanly to a fresh DB. This task's verification is implicit: the migration must apply without error to a fresh `pgvector/pgvector:pg16` container.
+
+Run before creating the file:
+
+```bash
+python scripts/ci/migrations_smoke.py
+```
+
+Expected: PASS at current migration count.
+
+- [ ] **Step 2: Create the migration file**
+
+```python
+"""Migration <NEXT_MIGRATION>: niche-aware topic discovery tables.
+
+Adds the data layer for the RAG pivot + niche-aware topic discovery
+design (docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).
+
+Tables:
+- niches                       — first-class niche configuration
+- niche_goals                  — weighted goals per niche (TRAFFIC, EDUCATION, ...)
+- niche_sources                — per-niche source plugin toggles + weights
+- topic_batches                — operator-interaction unit
+- topic_candidates             — external (HN, dev.to, web_search) candidates
+- internal_topic_candidates    — RAG-derived candidates (different shape)
+- discovery_runs               — observability: when sweeps fire + what they produce
+
+All UUIDs default via gen_random_uuid (pgcrypto extension already loaded).
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niches (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                slug            TEXT UNIQUE NOT NULL,
+                name            TEXT NOT NULL,
+                active          BOOLEAN NOT NULL DEFAULT true,
+                target_audience_tags TEXT[] NOT NULL DEFAULT '{}',
+                writer_prompt_override TEXT,
+                writer_rag_mode TEXT NOT NULL DEFAULT 'TOPIC_ONLY'
+                    CHECK (writer_rag_mode IN ('TOPIC_ONLY','CITATION_BUDGET','STORY_SPINE','TWO_PASS')),
+                batch_size      INT NOT NULL DEFAULT 5 CHECK (batch_size BETWEEN 1 AND 20),
+                discovery_cadence_minute_floor INT NOT NULL DEFAULT 60 CHECK (discovery_cadence_minute_floor >= 1),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niche_goals (
+                niche_id   UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                goal_type  TEXT NOT NULL
+                    CHECK (goal_type IN ('TRAFFIC','EDUCATION','BRAND','AUTHORITY','REVENUE','COMMUNITY','NICHE_DEPTH')),
+                weight_pct INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+                PRIMARY KEY (niche_id, goal_type)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niche_sources (
+                niche_id    UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_name TEXT NOT NULL,
+                enabled     BOOLEAN NOT NULL DEFAULT true,
+                weight_pct  INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+                PRIMARY KEY (niche_id, source_name)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS topic_batches (
+                id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                niche_id     UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                status       TEXT NOT NULL CHECK (status IN ('open','resolved','expired')),
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                expires_at   TIMESTAMPTZ NOT NULL,
+                resolved_at  TIMESTAMPTZ,
+                picked_candidate_id UUID,
+                picked_candidate_kind TEXT CHECK (picked_candidate_kind IN ('external','internal') OR picked_candidate_kind IS NULL)
+            )
+        """)
+        await conn.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_one_open_batch_per_niche
+                ON topic_batches (niche_id) WHERE status = 'open'
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS topic_candidates (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_name     TEXT NOT NULL,
+                source_ref      TEXT NOT NULL,
+                title           TEXT NOT NULL,
+                summary         TEXT,
+                score           NUMERIC NOT NULL,
+                score_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+                rank_in_batch   INT NOT NULL,
+                operator_rank   INT,
+                operator_edited_topic TEXT,
+                operator_edited_angle TEXT,
+                decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+                carried_from_batch_id UUID REFERENCES topic_batches(id),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE (batch_id, source_name, source_ref)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS internal_topic_candidates (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_kind     TEXT NOT NULL
+                    CHECK (source_kind IN ('claude_session','brain_knowledge','audit_event','git_commit','decision_log','memory_file','post_history')),
+                primary_ref     TEXT NOT NULL,
+                supporting_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+                distilled_topic TEXT NOT NULL,
+                distilled_angle TEXT NOT NULL,
+                score           NUMERIC NOT NULL,
+                score_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+                rank_in_batch   INT NOT NULL,
+                operator_rank   INT,
+                operator_edited_topic TEXT,
+                operator_edited_angle TEXT,
+                decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+                carried_from_batch_id UUID REFERENCES topic_batches(id),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS discovery_runs (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                finished_at     TIMESTAMPTZ,
+                candidates_generated      INT,
+                candidates_carried_forward INT,
+                batch_id        UUID REFERENCES topic_batches(id),
+                error           TEXT
+            )
+        """)
+        # Helpful indexes
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_topic_candidates_batch ON topic_candidates(batch_id)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_internal_topic_candidates_batch ON internal_topic_candidates(batch_id)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_discovery_runs_niche_started ON discovery_runs(niche_id, started_at DESC)")
+        logger.info("Created niche topic-discovery tables (<NEXT_MIGRATION>)")
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        for tbl in (
+            "discovery_runs", "internal_topic_candidates", "topic_candidates",
+            "topic_batches", "niche_sources", "niche_goals", "niches",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        logger.info("Dropped niche topic-discovery tables (<NEXT_MIGRATION> down)")
+```
+
+Replace `<NEXT_MIGRATION>` everywhere in the body with the actual zero-padded number you picked in pre-flight.
+
+- [ ] **Step 3: Run migrations smoke against the new file**
+
+```bash
+python scripts/ci/migrations_smoke.py
+```
+
+Expected: PASS — schema_migrations row count matches file count.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cofounder_agent/services/migrations/<NEXT_MIGRATION>_create_niche_topic_discovery_tables.py
+git commit -m "feat(niche): create niche topic-discovery tables (<NEXT_MIGRATION>)"
+```
+
+---
+
+## Task 2: NicheService — CRUD on niches / goals / sources
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/niche_service.py`
+- Test: `src/cofounder_agent/tests/unit/services/test_niche_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/services/test_niche_service.py
+import pytest
+from services.niche_service import NicheService, Niche, NicheGoal, NicheSource
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_create_niche_inserts_row(db_pool):
+    svc = NicheService(db_pool)
+    niche = await svc.create(slug="glad-labs", name="Glad Labs",
+                             writer_rag_mode="TWO_PASS", batch_size=5)
+    assert isinstance(niche, Niche)
+    assert niche.slug == "glad-labs"
+    assert niche.writer_rag_mode == "TWO_PASS"
+    fetched = await svc.get_by_slug("glad-labs")
+    assert fetched.id == niche.id
+
+
+async def test_create_niche_rejects_duplicate_slug(db_pool):
+    svc = NicheService(db_pool)
+    await svc.create(slug="dupe", name="A")
+    with pytest.raises(Exception):
+        await svc.create(slug="dupe", name="B")
+
+
+async def test_set_goals_validates_weights_sum_to_100(db_pool):
+    svc = NicheService(db_pool)
+    n = await svc.create(slug="x", name="X")
+    with pytest.raises(ValueError, match="weights must sum to ~100"):
+        await svc.set_goals(n.id, [
+            NicheGoal(goal_type="TRAFFIC", weight_pct=30),
+            NicheGoal(goal_type="EDUCATION", weight_pct=20),
+            # sums to 50, should reject
+        ])
+    # 100 ± 1 tolerance is fine
+    await svc.set_goals(n.id, [
+        NicheGoal(goal_type="TRAFFIC", weight_pct=60),
+        NicheGoal(goal_type="EDUCATION", weight_pct=40),
+    ])
+    fetched = await svc.get_goals(n.id)
+    assert {g.goal_type: g.weight_pct for g in fetched} == {"TRAFFIC": 60, "EDUCATION": 40}
+
+
+async def test_set_sources_replaces_prior_config(db_pool):
+    svc = NicheService(db_pool)
+    n = await svc.create(slug="y", name="Y")
+    await svc.set_sources(n.id, [
+        NicheSource(source_name="hackernews", enabled=True, weight_pct=50),
+        NicheSource(source_name="devto", enabled=True, weight_pct=50),
+    ])
+    await svc.set_sources(n.id, [
+        NicheSource(source_name="internal_rag", enabled=True, weight_pct=100),
+    ])
+    fetched = await svc.get_sources(n.id)
+    assert len(fetched) == 1
+    assert fetched[0].source_name == "internal_rag"
+```
+
+The `db_pool` fixture should already exist in `tests/unit/conftest.py` — if not, the implementer adds it (returns a fresh asyncpg pool against a test DB).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_niche_service.py -v
+```
+
+Expected: ImportError or ModuleNotFoundError.
+
+- [ ] **Step 3: Implement NicheService**
+
+```python
+# services/niche_service.py
+"""CRUD service for niches + their goals + their source configs.
+
+Niches are the first-class configuration unit for the topic-discovery + RAG
+pivot (see docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).
+Glad Labs is the first niche; future operators add their own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+_VALID_GOAL_TYPES = frozenset({
+    "TRAFFIC", "EDUCATION", "BRAND", "AUTHORITY",
+    "REVENUE", "COMMUNITY", "NICHE_DEPTH",
+})
+
+_VALID_RAG_MODES = frozenset({
+    "TOPIC_ONLY", "CITATION_BUDGET", "STORY_SPINE", "TWO_PASS",
+})
+
+
+@dataclass(frozen=True)
+class Niche:
+    id: UUID
+    slug: str
+    name: str
+    active: bool
+    target_audience_tags: list[str]
+    writer_prompt_override: str | None
+    writer_rag_mode: str
+    batch_size: int
+    discovery_cadence_minute_floor: int
+
+
+@dataclass(frozen=True)
+class NicheGoal:
+    goal_type: str
+    weight_pct: int
+
+
+@dataclass(frozen=True)
+class NicheSource:
+    source_name: str
+    enabled: bool
+    weight_pct: int
+
+
+class NicheService:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def create(
+        self, *, slug: str, name: str,
+        target_audience_tags: list[str] | None = None,
+        writer_prompt_override: str | None = None,
+        writer_rag_mode: str = "TOPIC_ONLY",
+        batch_size: int = 5,
+        discovery_cadence_minute_floor: int = 60,
+    ) -> Niche:
+        if writer_rag_mode not in _VALID_RAG_MODES:
+            raise ValueError(f"invalid writer_rag_mode: {writer_rag_mode!r}")
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO niches (slug, name, target_audience_tags,
+                                    writer_prompt_override, writer_rag_mode,
+                                    batch_size, discovery_cadence_minute_floor)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                RETURNING *
+                """,
+                slug, name, list(target_audience_tags or []),
+                writer_prompt_override, writer_rag_mode,
+                batch_size, discovery_cadence_minute_floor,
+            )
+        return _row_to_niche(row)
+
+    async def get_by_slug(self, slug: str) -> Niche | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM niches WHERE slug = $1", slug)
+        return _row_to_niche(row) if row else None
+
+    async def get_by_id(self, niche_id: UUID) -> Niche | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM niches WHERE id = $1", niche_id)
+        return _row_to_niche(row) if row else None
+
+    async def list_active(self) -> list[Niche]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM niches WHERE active ORDER BY slug")
+        return [_row_to_niche(r) for r in rows]
+
+    async def set_goals(self, niche_id: UUID, goals: list[NicheGoal]) -> None:
+        bad = [g.goal_type for g in goals if g.goal_type not in _VALID_GOAL_TYPES]
+        if bad:
+            raise ValueError(f"invalid goal_type(s): {bad}")
+        total = sum(g.weight_pct for g in goals)
+        if not 99 <= total <= 101:
+            raise ValueError(f"weights must sum to ~100, got {total}")
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("DELETE FROM niche_goals WHERE niche_id = $1", niche_id)
+                for g in goals:
+                    await conn.execute(
+                        "INSERT INTO niche_goals (niche_id, goal_type, weight_pct) VALUES ($1,$2,$3)",
+                        niche_id, g.goal_type, g.weight_pct,
+                    )
+
+    async def get_goals(self, niche_id: UUID) -> list[NicheGoal]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT goal_type, weight_pct FROM niche_goals WHERE niche_id = $1 ORDER BY weight_pct DESC",
+                niche_id,
+            )
+        return [NicheGoal(goal_type=r["goal_type"], weight_pct=r["weight_pct"]) for r in rows]
+
+    async def set_sources(self, niche_id: UUID, sources: list[NicheSource]) -> None:
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("DELETE FROM niche_sources WHERE niche_id = $1", niche_id)
+                for s in sources:
+                    await conn.execute(
+                        "INSERT INTO niche_sources (niche_id, source_name, enabled, weight_pct) VALUES ($1,$2,$3,$4)",
+                        niche_id, s.source_name, s.enabled, s.weight_pct,
+                    )
+
+    async def get_sources(self, niche_id: UUID) -> list[NicheSource]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT source_name, enabled, weight_pct FROM niche_sources "
+                "WHERE niche_id = $1 ORDER BY weight_pct DESC",
+                niche_id,
+            )
+        return [NicheSource(**dict(r)) for r in rows]
+
+
+def _row_to_niche(row: Any) -> Niche:
+    return Niche(
+        id=row["id"], slug=row["slug"], name=row["name"], active=row["active"],
+        target_audience_tags=list(row["target_audience_tags"] or []),
+        writer_prompt_override=row["writer_prompt_override"],
+        writer_rag_mode=row["writer_rag_mode"],
+        batch_size=row["batch_size"],
+        discovery_cadence_minute_floor=row["discovery_cadence_minute_floor"],
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_niche_service.py -v
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/niche_service.py src/cofounder_agent/tests/unit/services/test_niche_service.py
+git commit -m "feat(niche): NicheService CRUD over niches/goals/sources tables"
+```
+
+---
+
+## Task 3: Goal vectors — precomputed embeddings + weighted cosine scoring
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/topic_ranking.py` (start the file; later tasks add to it)
+- Test: `src/cofounder_agent/tests/unit/services/test_topic_ranking.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/services/test_topic_ranking.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from services.topic_ranking import (
+    GOAL_DESCRIPTIONS, goal_vector_for, weighted_cosine_score,
+)
+from services.niche_service import NicheGoal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_all_goal_types_have_descriptions():
+    expected = {"TRAFFIC","EDUCATION","BRAND","AUTHORITY","REVENUE","COMMUNITY","NICHE_DEPTH"}
+    assert set(GOAL_DESCRIPTIONS.keys()) == expected
+    for desc in GOAL_DESCRIPTIONS.values():
+        assert isinstance(desc, str) and len(desc) > 20
+
+
+async def test_goal_vector_caches_embeddings(monkeypatch):
+    calls = []
+    async def fake_embed(text):
+        calls.append(text)
+        return [0.1] * 768
+    monkeypatch.setattr("services.topic_ranking._embed_text_cached", fake_embed)
+    v1 = await goal_vector_for("TRAFFIC")
+    v2 = await goal_vector_for("TRAFFIC")
+    assert v1 == v2
+    # _embed_text_cached itself caches, so calls should be 1
+    assert len(calls) == 1
+
+
+async def test_weighted_cosine_score_combines_per_goal_signals():
+    candidate_vec = [1.0, 0.0, 0.0]
+    # Two goals; one aligns perfectly with candidate, the other is orthogonal.
+    goal_vecs = {"TRAFFIC": [1.0, 0.0, 0.0], "EDUCATION": [0.0, 1.0, 0.0]}
+    weights = [NicheGoal("TRAFFIC", 60), NicheGoal("EDUCATION", 40)]
+    score, breakdown = weighted_cosine_score(candidate_vec, goal_vecs, weights)
+    # 0.6 * 1.0 (perfect TRAFFIC) + 0.4 * 0.0 (orthogonal EDUCATION) = 0.6
+    assert score == pytest.approx(0.6, abs=0.01)
+    assert breakdown == {"TRAFFIC": pytest.approx(0.6, abs=0.01),
+                         "EDUCATION": pytest.approx(0.0, abs=0.01)}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_ranking.py -v
+```
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement goal vectors + weighted cosine**
+
+```python
+# services/topic_ranking.py
+"""Topic candidate ranking — goal vectors + hybrid embed/LLM scoring + decay rerank.
+
+Spec §"Goal vectors", §"Discovery sweep" steps 4-5.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+from typing import Any
+
+from services.logger_config import get_logger
+from services.niche_service import NicheGoal
+
+logger = get_logger(__name__)
+
+
+# Per the spec — fixed prose anchor for each goal type. Cached embeddings
+# are computed lazily on first use and live for the process lifetime.
+GOAL_DESCRIPTIONS: dict[str, str] = {
+    "TRAFFIC":     "Topic likely to attract organic search traffic; trending keyword, broad appeal, evergreen demand.",
+    "EDUCATION":   "Topic that teaches the reader something concrete and useful they didn't know before.",
+    "BRAND":       "Topic that reinforces the operator's positioning and unique perspective.",
+    "AUTHORITY":   "Topic that demonstrates the operator's depth and expertise on something specific.",
+    "REVENUE":     "Topic that drives a commercial outcome: signups, sales, conversions, paid feature awareness.",
+    "COMMUNITY":   "Topic that resonates with the operator's existing audience; sparks discussion, shares, replies.",
+    "NICHE_DEPTH": "Topic that goes deep on the operator's niche specialty rather than broad-audience content.",
+}
+
+
+_GOAL_VEC_CACHE: dict[str, list[float]] = {}
+
+
+async def _embed_text_cached(text: str) -> list[float]:
+    """Embed via the existing service; the embedding service is responsible
+    for its own caching (or not). This indirection lets tests monkeypatch.
+    """
+    from services.embedding_service import embed_text
+    return await embed_text(text)
+
+
+async def goal_vector_for(goal_type: str) -> list[float]:
+    if goal_type in _GOAL_VEC_CACHE:
+        return _GOAL_VEC_CACHE[goal_type]
+    if goal_type not in GOAL_DESCRIPTIONS:
+        raise ValueError(f"unknown goal_type: {goal_type!r}")
+    vec = await _embed_text_cached(GOAL_DESCRIPTIONS[goal_type])
+    _GOAL_VEC_CACHE[goal_type] = vec
+    return vec
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def weighted_cosine_score(
+    candidate_vec: list[float],
+    goal_vecs: dict[str, list[float]],
+    weights: list[NicheGoal],
+) -> tuple[float, dict[str, float]]:
+    """Returns (overall_score, per_goal_breakdown).
+
+    overall_score = Σ over goals of (cosine(candidate, goal_vec) * weight_pct/100).
+    breakdown maps goal_type → its weighted contribution.
+    """
+    breakdown: dict[str, float] = {}
+    total = 0.0
+    for g in weights:
+        gv = goal_vecs.get(g.goal_type)
+        if gv is None:
+            continue
+        cos = cosine_similarity(candidate_vec, gv)
+        contribution = cos * (g.weight_pct / 100.0)
+        breakdown[g.goal_type] = contribution
+        total += contribution
+    return total, breakdown
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_ranking.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/topic_ranking.py src/cofounder_agent/tests/unit/services/test_topic_ranking.py
+git commit -m "feat(ranking): goal vectors + weighted cosine scoring helpers"
+```
+
+---
+
+## Task 4: LLM final-scorer + decay re-rank
+
+**Files:**
+
+- Modify: `src/cofounder_agent/services/topic_ranking.py` (add functions)
+- Modify: `src/cofounder_agent/tests/unit/services/test_topic_ranking.py` (extend)
+
+- [ ] **Step 1: Write the failing tests for LLM scorer + decay**
+
+Append to `test_topic_ranking.py`:
+
+```python
+async def test_llm_final_score_returns_score_per_candidate(monkeypatch):
+    from services.topic_ranking import llm_final_score, ScoredCandidate
+
+    async def fake_ollama_chat(prompt: str, *, model: str) -> str:
+        # Simulated JSON response from glm-4.7-5090
+        return '{"c1": {"score": 87.5, "breakdown": {"TRAFFIC": 0.5, "EDUCATION": 0.375}},'  \
+               ' "c2": {"score": 42.0, "breakdown": {"TRAFFIC": 0.2, "EDUCATION": 0.22}}}'
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_ollama_chat)
+
+    candidates = [
+        ScoredCandidate(id="c1", title="A", summary="x", embedding_score=0.6),
+        ScoredCandidate(id="c2", title="B", summary="y", embedding_score=0.4),
+    ]
+    weights = [NicheGoal("TRAFFIC", 60), NicheGoal("EDUCATION", 40)]
+    scored = await llm_final_score(candidates, weights)
+    assert scored["c1"].score == 87.5
+    assert scored["c2"].score == 42.0
+
+
+def test_apply_decay_multiplies_score():
+    from services.topic_ranking import apply_decay
+    assert apply_decay(score=80, decay_factor=1.0) == 80
+    assert apply_decay(score=80, decay_factor=0.7) == pytest.approx(56)
+    assert apply_decay(score=80, decay_factor=0.49) == pytest.approx(39.2)
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_ranking.py::test_llm_final_score_returns_score_per_candidate tests/unit/services/test_topic_ranking.py::test_apply_decay_multiplies_score -v
+```
+
+Expected: ImportError on `llm_final_score`/`apply_decay`/`ScoredCandidate`.
+
+- [ ] **Step 3: Implement LLM final-scorer + decay**
+
+Append to `services/topic_ranking.py`:
+
+```python
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class ScoredCandidate:
+    id: str
+    title: str
+    summary: str | None
+    embedding_score: float
+    llm_score: float | None = None
+    score_breakdown: dict[str, float] | None = None
+
+
+async def _ollama_chat_json(prompt: str, *, model: str) -> str:
+    """One-shot Ollama chat call; returns the assistant's content as a string.
+    Indirection so tests can monkeypatch.
+    """
+    import httpx
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "format": "json",
+    }
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post("http://localhost:11434/api/chat", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+    return data["message"]["content"]
+
+
+async def llm_final_score(
+    candidates: list[ScoredCandidate],
+    weights: list[NicheGoal],
+    *,
+    model: str = "glm-4.7-5090:latest",
+) -> dict[str, ScoredCandidate]:
+    """Single LLM call ranks the (already-shortlisted) candidates against weighted goals.
+
+    Returns the same candidates with `llm_score` and `score_breakdown` filled in,
+    keyed by candidate id.
+    """
+    weights_descr = "\n".join(f"- {g.goal_type} (weight {g.weight_pct}%): {GOAL_DESCRIPTIONS[g.goal_type]}" for g in weights)
+    cand_block = "\n".join(f"[{c.id}] {c.title} — {c.summary or ''}" for c in candidates)
+    prompt = f"""You are scoring topic candidates for a content pipeline against the operator's weighted goals.
+
+Goals (weight in pct):
+{weights_descr}
+
+Candidates:
+{cand_block}
+
+Return STRICT JSON keyed by candidate id, of the form:
+{{"<id>": {{"score": <0-100>, "breakdown": {{"<GOAL_TYPE>": <weighted contribution 0-1>, ...}}}}, ...}}
+
+The breakdown values per candidate should approximately sum to (score / 100).
+Return ONLY the JSON, no commentary.
+"""
+    raw = await _ollama_chat_json(prompt, model=model)
+    parsed = json.loads(raw)
+    result: dict[str, ScoredCandidate] = {}
+    for c in candidates:
+        score_blob = parsed.get(c.id)
+        if score_blob is None:
+            logger.warning("LLM scorer omitted candidate %s; defaulting to embedding_score", c.id)
+            score_blob = {"score": c.embedding_score * 100, "breakdown": {}}
+        c.llm_score = float(score_blob.get("score", 0.0))
+        c.score_breakdown = dict(score_blob.get("breakdown", {}))
+        result[c.id] = c
+    return result
+
+
+def apply_decay(*, score: float, decay_factor: float) -> float:
+    """Effective score = raw score × decay_factor. Used both at insertion time
+    (decay_factor=1.0 for fresh, <1.0 for carried-forward) and at re-rank time
+    (carried-forward candidates get an additional decay multiplier applied here).
+    """
+    return score * decay_factor
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_ranking.py -v
+```
+
+Expected: 5 PASSED total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/topic_ranking.py src/cofounder_agent/tests/unit/services/test_topic_ranking.py
+git commit -m "feat(ranking): LLM final-scorer + decay multiplier"
+```
+
+---
+
+## Task 5: InternalRagSource — generate candidates from internal corpus
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/internal_rag_source.py`
+- Test: `src/cofounder_agent/tests/unit/services/test_internal_rag_source.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/services/test_internal_rag_source.py
+import pytest
+from unittest.mock import AsyncMock
+from services.internal_rag_source import InternalRagSource, InternalCandidate
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_generate_pulls_top_k_per_source_kind(db_pool, monkeypatch):
+    # The source should query the embeddings table for each enabled source_kind
+    # and return distilled candidates.
+    src = InternalRagSource(db_pool)
+    # Mock the LLM distillation step — it turns a snippet into (topic, angle).
+    async def fake_distill(snippets):
+        return ("How we handled OAuth phase 1", "Why client credentials grant first")
+    monkeypatch.setattr(src, "_distill_topic_angle", fake_distill)
+
+    candidates = await src.generate(
+        niche_id="00000000-0000-0000-0000-000000000001",
+        source_kinds=["claude_session", "brain_knowledge"],
+        per_kind_limit=2,
+    )
+    assert all(isinstance(c, InternalCandidate) for c in candidates)
+    # at most 2 * 2 = 4 candidates if data exists for both source_kinds
+    assert len(candidates) <= 4
+    if candidates:
+        c = candidates[0]
+        assert c.distilled_topic
+        assert c.distilled_angle
+        assert c.primary_ref
+        assert isinstance(c.supporting_refs, list)
+```
+
+This test depends on having SOME embedding data; for unit tests, the implementer should also add a fixture that seeds 2-3 fake rows in the embeddings table. If that's too heavy for unit tests, mark it `@pytest.mark.integration` and skip in unit runs.
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_internal_rag_source.py -v
+```
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement InternalRagSource**
+
+```python
+# services/internal_rag_source.py
+"""Generate topic candidates from the internal embedded corpus.
+
+The Glad Labs writing pivot — instead of summarising external content,
+mine our own claude_sessions / brain_knowledge / audit / decision_log /
+git history / memory / posts for storyworthy events and turn each into
+a proposed topic + angle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+VALID_SOURCE_KINDS = (
+    "claude_session", "brain_knowledge", "audit_event",
+    "git_commit", "decision_log", "memory_file", "post_history",
+)
+
+
+@dataclass
+class InternalCandidate:
+    source_kind: str
+    primary_ref: str           # the source_table row id / commit sha / file path
+    distilled_topic: str
+    distilled_angle: str
+    supporting_refs: list[dict[str, Any]] = field(default_factory=list)
+    raw_snippet: str = ""
+
+
+class InternalRagSource:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def generate(
+        self,
+        *,
+        niche_id: UUID | str,
+        source_kinds: list[str],
+        per_kind_limit: int = 5,
+    ) -> list[InternalCandidate]:
+        bad = [s for s in source_kinds if s not in VALID_SOURCE_KINDS]
+        if bad:
+            raise ValueError(f"unknown source_kinds: {bad}")
+
+        results: list[InternalCandidate] = []
+        for kind in source_kinds:
+            snippets = await self._fetch_recent_snippets(kind, per_kind_limit)
+            for primary_ref, snippet, supporting in snippets:
+                topic, angle = await self._distill_topic_angle(
+                    [snippet] + [s["snippet"] for s in supporting],
+                )
+                results.append(InternalCandidate(
+                    source_kind=kind,
+                    primary_ref=primary_ref,
+                    distilled_topic=topic,
+                    distilled_angle=angle,
+                    supporting_refs=supporting,
+                    raw_snippet=snippet,
+                ))
+        return results
+
+    async def _fetch_recent_snippets(
+        self, source_kind: str, limit: int,
+    ) -> list[tuple[str, str, list[dict[str, Any]]]]:
+        """Pull the most-recent N entries for this kind from the embeddings table.
+
+        Returns list of (primary_ref, snippet, supporting_refs).
+        Mapping source_kind → embeddings.source_table:
+          claude_session → 'claude_sessions'
+          brain_knowledge → 'brain'
+          audit_event → 'audit'
+          git_commit → (TBD: needs git log query, not embeddings)
+          decision_log → 'memory' filtered to decision_log
+          memory_file → 'memory'
+          post_history → 'posts'
+        """
+        # Translate source_kind to the embeddings.source_table name
+        table_map = {
+            "claude_session": "claude_sessions",
+            "brain_knowledge": "brain",
+            "audit_event": "audit",
+            "decision_log": "memory",
+            "memory_file": "memory",
+            "post_history": "posts",
+        }
+        st = table_map.get(source_kind)
+        if st is None:
+            # git_commit not yet implemented — would query git log directly
+            return []
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT source_id, text_preview
+                  FROM embeddings
+                 WHERE source_table = $1
+                 ORDER BY created_at DESC
+                 LIMIT $2
+                """,
+                st, limit,
+            )
+        return [(str(r["source_id"]), r["text_preview"] or "", []) for r in rows]
+
+    async def _distill_topic_angle(self, snippets: list[str]) -> tuple[str, str]:
+        """Run a small LLM call to extract a proposed (topic, angle) from raw snippets."""
+        from services.topic_ranking import _ollama_chat_json
+        joined = "\n---\n".join(s[:600] for s in snippets if s)
+        prompt = f"""Read the snippets from an AI-operated content business's internal records.
+Extract a proposed blog post topic and the unique angle (the "why this matters / what we learned").
+
+Snippets:
+{joined}
+
+Return STRICT JSON: {{"topic": "<short title>", "angle": "<one-sentence framing>"}}.
+"""
+        raw = await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+        import json
+        parsed = json.loads(raw)
+        return parsed.get("topic", "Untitled"), parsed.get("angle", "")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_internal_rag_source.py -v
+```
+
+Expected: 1 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/internal_rag_source.py src/cofounder_agent/tests/unit/services/test_internal_rag_source.py
+git commit -m "feat(rag): InternalRagSource — generate candidates from internal corpus"
+```
+
+---
+
+## Task 6: TopicBatchService — orchestrator (discovery → rank → batch)
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/topic_batch_service.py`
+- Test: `src/cofounder_agent/tests/unit/services/test_topic_batch_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/services/test_topic_batch_service.py
+import pytest
+from datetime import timedelta
+from services.topic_batch_service import TopicBatchService
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_run_sweep_creates_open_batch_with_candidates(db_pool, monkeypatch):
+    """End-to-end: pick a niche, run sweep, expect an open topic_batch row
+    with N candidates spanning topic_candidates + internal_topic_candidates."""
+    # Seed a niche
+    from services.niche_service import NicheService, NicheGoal, NicheSource
+    nsvc = NicheService(db_pool)
+    n = await nsvc.create(slug="test-niche", name="Test", batch_size=3)
+    await nsvc.set_goals(n.id, [
+        NicheGoal("TRAFFIC", 50), NicheGoal("EDUCATION", 50),
+    ])
+    await nsvc.set_sources(n.id, [
+        NicheSource("internal_rag", enabled=True, weight_pct=100),
+    ])
+
+    # Mock the internal source to return 5 fake candidates
+    from services.internal_rag_source import InternalCandidate
+    async def fake_internal_generate(self, **kwargs):
+        return [InternalCandidate(
+            source_kind="claude_session",
+            primary_ref=f"sess-{i}",
+            distilled_topic=f"Topic {i}",
+            distilled_angle=f"Angle {i}",
+        ) for i in range(5)]
+    monkeypatch.setattr(
+        "services.internal_rag_source.InternalRagSource.generate",
+        fake_internal_generate,
+    )
+
+    # Mock the embedding step + LLM final scorer
+    async def fake_embed_text(text):
+        return [0.1] * 768
+    monkeypatch.setattr("services.embedding_service.embed_text", fake_embed_text)
+
+    async def fake_llm_score(candidates, weights, *, model="..."):
+        return {c.id: type(c)(c.id, c.title, c.summary, c.embedding_score,
+                              llm_score=80 - i * 5, score_breakdown={})
+                for i, c in enumerate(candidates)}
+    monkeypatch.setattr("services.topic_ranking.llm_final_score", fake_llm_score)
+
+    svc = TopicBatchService(db_pool)
+    batch = await svc.run_sweep(niche_id=n.id)
+    assert batch is not None
+    assert batch.status == "open"
+    # batch_size=3, we generated 5 → top 3 in the batch
+    assert batch.candidate_count == 3
+
+
+async def test_only_one_open_batch_per_niche(db_pool):
+    from services.niche_service import NicheService
+    nsvc = NicheService(db_pool)
+    n = await nsvc.create(slug="solo", name="Solo")
+    svc = TopicBatchService(db_pool)
+    # First sweep: should succeed (mocked source returns nothing → empty batch
+    # is fine for this test). Second sweep with an open batch already → must
+    # raise or return None.
+    # Implementation detail: TopicBatchService should check the unique partial
+    # index OR check before insert.
+```
+
+(The second test is a sketch — implementer fleshes it out per their final API.)
+
+- [ ] **Step 2: Run test to verify failure**
+
+Expected: ImportError on `TopicBatchService`.
+
+- [ ] **Step 3: Implement TopicBatchService**
+
+```python
+# services/topic_batch_service.py
+"""Topic batch orchestrator — replaces topic_proposal_service.
+
+Per-niche flow:
+  1. discover candidates (external source plugins + InternalRagSource) per
+     niche_sources weights → pool of ~20
+  2. carry-forward leftover candidates from prior batch with decay
+  3. embedding pre-rank against goal vectors → top 10
+  4. LLM final-score on the top 10 → final batch_size winners
+  5. write topic_batch + topic_candidates / internal_topic_candidates rows
+  6. open the topic_decision approval gate
+  7. record discovery_run
+
+See spec §"Flow" + §"Discovery sweep".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+from services.niche_service import NicheService, Niche, NicheGoal, NicheSource
+from services.topic_ranking import (
+    GOAL_DESCRIPTIONS, ScoredCandidate, apply_decay,
+    cosine_similarity, goal_vector_for, llm_final_score, weighted_cosine_score,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class BatchSnapshot:
+    id: UUID
+    niche_id: UUID
+    status: str
+    candidate_count: int
+    expires_at: datetime
+
+
+class TopicBatchService:
+    def __init__(self, pool):
+        self._pool = pool
+        self._niche_svc = NicheService(pool)
+
+    async def run_sweep(self, *, niche_id: UUID) -> BatchSnapshot | None:
+        niche = await self._niche_svc.get_by_id(niche_id)
+        if niche is None:
+            raise ValueError(f"unknown niche_id: {niche_id}")
+        if not await self._floor_elapsed(niche):
+            logger.info("Sweep skipped — floor not elapsed for niche %s", niche.slug)
+            return None
+        if await self._open_batch_exists(niche.id):
+            logger.info("Sweep skipped — open batch already exists for niche %s", niche.slug)
+            return None
+
+        async with self._pool.acquire() as conn:
+            run = await conn.fetchrow(
+                "INSERT INTO discovery_runs (niche_id) VALUES ($1) RETURNING *",
+                niche.id,
+            )
+        run_id = run["id"]
+
+        try:
+            external = await self._discover_external(niche)
+            internal = await self._discover_internal(niche)
+            carried = await self._load_carry_forward(niche.id)
+
+            # Mark carried candidates with their existing decay_factor (already
+            # decayed when last batch resolved); fresh candidates start at 1.0.
+            pool_external, pool_internal = await self._embed_and_pre_rank(
+                niche, external + carried["external"],
+                internal + carried["internal"],
+            )
+
+            top10 = pool_external[:5] + pool_internal[:5]  # mix per source kind
+            scored = await llm_final_score(top10, await self._niche_svc.get_goals(niche.id))
+
+            # Sort by llm_score (post-decay), pick batch_size
+            ranked = sorted(scored.values(), key=lambda c: -(c.llm_score or 0))[: niche.batch_size]
+
+            batch = await self._write_batch(niche, ranked, pool_external, pool_internal)
+
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE discovery_runs SET finished_at = NOW(), batch_id = $1, "
+                    "candidates_generated = $2, candidates_carried_forward = $3 "
+                    "WHERE id = $4",
+                    batch.id,
+                    len(external) + len(internal),
+                    len(carried["external"]) + len(carried["internal"]),
+                    run_id,
+                )
+
+            await self._open_topic_decision_gate(batch)
+            return batch
+        except Exception as e:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE discovery_runs SET finished_at = NOW(), error = $1 WHERE id = $2",
+                    str(e), run_id,
+                )
+            raise
+
+    # -- helpers (stubs the implementer fleshes out) --
+
+    async def _floor_elapsed(self, niche: Niche) -> bool:
+        async with self._pool.acquire() as conn:
+            last = await conn.fetchval(
+                "SELECT MAX(started_at) FROM discovery_runs WHERE niche_id = $1",
+                niche.id,
+            )
+        if last is None:
+            return True
+        floor = timedelta(minutes=niche.discovery_cadence_minute_floor)
+        return (datetime.now(timezone.utc) - last) >= floor
+
+    async def _open_batch_exists(self, niche_id: UUID) -> bool:
+        async with self._pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM topic_batches WHERE niche_id = $1 AND status = 'open'",
+                niche_id,
+            )
+        return count > 0
+
+    async def _discover_external(self, niche: Niche) -> list[dict[str, Any]]:
+        """Call the existing topic_discovery.TopicDiscovery for non-internal sources."""
+        from services.topic_discovery import TopicDiscovery
+        # TopicDiscovery returns DiscoveredTopic; convert to dicts here for ranking.
+        # Skip 'internal_rag' source — that's handled by _discover_internal.
+        sources = await self._niche_svc.get_sources(niche.id)
+        external_sources = [s for s in sources if s.enabled and s.source_name != "internal_rag"]
+        if not external_sources:
+            return []
+        # Plumbing: instantiate TopicDiscovery with site_config + an enabled-source filter
+        # implementer: use existing TopicDiscovery patterns from services/topic_discovery.py
+        return []  # placeholder — wire to topic_discovery on implementation
+
+    async def _discover_internal(self, niche: Niche) -> list[dict[str, Any]]:
+        sources = await self._niche_svc.get_sources(niche.id)
+        if not any(s.source_name == "internal_rag" and s.enabled for s in sources):
+            return []
+        from services.internal_rag_source import InternalRagSource
+        rag = InternalRagSource(self._pool)
+        kinds = ["claude_session", "brain_knowledge", "audit_event",
+                 "decision_log", "memory_file", "post_history"]
+        cands = await rag.generate(niche_id=niche.id, source_kinds=kinds, per_kind_limit=4)
+        return [{"kind": "internal", "data": c} for c in cands]
+
+    async def _load_carry_forward(self, niche_id: UUID) -> dict[str, list]:
+        """Pull unpicked candidates from the most recent resolved batch and
+        return them with decay_factor pre-multiplied by 0.7."""
+        async with self._pool.acquire() as conn:
+            ext = await conn.fetch(
+                """
+                SELECT * FROM topic_candidates
+                 WHERE niche_id = $1 AND operator_rank IS NULL
+                   AND batch_id IN (
+                       SELECT id FROM topic_batches
+                        WHERE niche_id = $1 AND status = 'resolved'
+                     ORDER BY resolved_at DESC LIMIT 1
+                   )
+                """,
+                niche_id,
+            )
+            int_ = await conn.fetch(
+                """
+                SELECT * FROM internal_topic_candidates
+                 WHERE niche_id = $1 AND operator_rank IS NULL
+                   AND batch_id IN (
+                       SELECT id FROM topic_batches
+                        WHERE niche_id = $1 AND status = 'resolved'
+                     ORDER BY resolved_at DESC LIMIT 1
+                   )
+                """,
+                niche_id,
+            )
+        # Multiply decay_factor in memory; actual rows get re-inserted into the new batch
+        return {
+            "external": [{"row": dict(r), "decay_factor": float(r["decay_factor"]) * 0.7} for r in ext],
+            "internal": [{"row": dict(r), "decay_factor": float(r["decay_factor"]) * 0.7} for r in int_],
+        }
+
+    async def _embed_and_pre_rank(
+        self, niche: Niche, external: list, internal: list,
+    ) -> tuple[list[ScoredCandidate], list[ScoredCandidate]]:
+        """Compute embedding + weighted cosine score per candidate.
+        Returns (top external, top internal) — top 5 each, sorted by score desc.
+        """
+        from services.embedding_service import embed_text
+        goals = await self._niche_svc.get_goals(niche.id)
+        goal_vecs = {g.goal_type: await goal_vector_for(g.goal_type) for g in goals}
+
+        async def score_one(text: str, decay: float) -> tuple[float, dict[str, float]]:
+            vec = await embed_text(text)
+            raw, breakdown = weighted_cosine_score(vec, goal_vecs, goals)
+            return apply_decay(score=raw, decay_factor=decay), breakdown
+
+        ext_scored: list[ScoredCandidate] = []
+        for item in external:
+            # implementer wires per-source candidate shape here
+            text = item.get("title", "") + " " + (item.get("summary", "") or "")
+            score, breakdown = await score_one(text, item.get("decay_factor", 1.0))
+            ext_scored.append(ScoredCandidate(
+                id=item.get("id") or item.get("source_ref") or text[:40],
+                title=item.get("title", "Untitled"),
+                summary=item.get("summary"),
+                embedding_score=score,
+                score_breakdown=breakdown,
+            ))
+
+        int_scored: list[ScoredCandidate] = []
+        for item in internal:
+            data = item.get("data") if "data" in item else item
+            text = (getattr(data, "distilled_topic", "") + " " + getattr(data, "distilled_angle", ""))
+            score, breakdown = await score_one(text, item.get("decay_factor", 1.0))
+            int_scored.append(ScoredCandidate(
+                id=str(getattr(data, "primary_ref", text[:40])),
+                title=getattr(data, "distilled_topic", "Untitled"),
+                summary=getattr(data, "distilled_angle", None),
+                embedding_score=score,
+                score_breakdown=breakdown,
+            ))
+
+        ext_scored.sort(key=lambda c: -c.embedding_score)
+        int_scored.sort(key=lambda c: -c.embedding_score)
+        return ext_scored[:5], int_scored[:5]
+
+    async def _write_batch(
+        self, niche: Niche, ranked: list[ScoredCandidate],
+        all_external: list, all_internal: list,
+    ) -> BatchSnapshot:
+        """Create the topic_batches row + the candidate rows for both tables."""
+        from datetime import datetime, timedelta, timezone
+        expires = datetime.now(timezone.utc) + timedelta(days=7)
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                batch = await conn.fetchrow(
+                    "INSERT INTO topic_batches (niche_id, status, expires_at) "
+                    "VALUES ($1, 'open', $2) RETURNING *",
+                    niche.id, expires,
+                )
+                rank_in_batch = 0
+                for c in ranked:
+                    rank_in_batch += 1
+                    # Disambiguate which table to write to by checking the
+                    # candidate's source signal — implementer wires this via
+                    # a flag on ScoredCandidate when discovery splits the pool.
+                    # Below uses a simple heuristic.
+                    is_internal = c.id in {sc.id for sc in [_["data"] for _ in all_internal if "data" in _]}
+                    if is_internal:
+                        await conn.execute(
+                            """
+                            INSERT INTO internal_topic_candidates
+                              (batch_id, niche_id, source_kind, primary_ref,
+                               supporting_refs, distilled_topic, distilled_angle,
+                               score, score_breakdown, rank_in_batch, decay_factor)
+                            VALUES ($1, $2, $3, $4, '[]'::jsonb, $5, $6, $7, $8::jsonb, $9, $10)
+                            """,
+                            batch["id"], niche.id, "claude_session", c.id,
+                            c.title, c.summary or "",
+                            c.llm_score or 0, _json(c.score_breakdown or {}),
+                            rank_in_batch, 1.0,
+                        )
+                    else:
+                        await conn.execute(
+                            """
+                            INSERT INTO topic_candidates
+                              (batch_id, niche_id, source_name, source_ref, title, summary,
+                               score, score_breakdown, rank_in_batch, decay_factor)
+                            VALUES ($1, $2, 'external', $3, $4, $5, $6, $7::jsonb, $8, $9)
+                            """,
+                            batch["id"], niche.id, c.id, c.title, c.summary,
+                            c.llm_score or 0, _json(c.score_breakdown or {}),
+                            rank_in_batch, 1.0,
+                        )
+        return BatchSnapshot(
+            id=batch["id"], niche_id=batch["niche_id"], status=batch["status"],
+            candidate_count=rank_in_batch, expires_at=batch["expires_at"],
+        )
+
+    async def _open_topic_decision_gate(self, batch: BatchSnapshot) -> None:
+        """Light-reuse of existing topic_decision gate.
+        Sets the gate's pending state via approval_service so the operator
+        is flagged. Implementer reads services/approval_service.py for the
+        exact API.
+        """
+        # Stub — implementer wires to approval_service.set_pending(...) or equiv.
+        logger.info("Opened topic_decision gate for batch %s", batch.id)
+
+
+def _json(obj: Any) -> str:
+    import json
+    return json.dumps(obj, default=str)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_batch_service.py -v
+```
+
+Expected: at least the first test PASSES; the second can be wired by the implementer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/topic_batch_service.py src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
+git commit -m "feat(topics): TopicBatchService orchestrator (discover→rank→batch→gate)"
+```
+
+---
+
+## Task 7: Operator interactions — resolve, edit, reject
+
+**Files:**
+
+- Modify: `src/cofounder_agent/services/topic_batch_service.py` (add methods)
+- Modify: `src/cofounder_agent/tests/unit/services/test_topic_batch_service.py` (extend)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+async def test_show_batch_returns_unified_ranked_view(db_pool):
+    # ... seed a batch with 2 external + 3 internal candidates ...
+    svc = TopicBatchService(db_pool)
+    view = await svc.show_batch(batch_id=BATCH_ID)
+    assert view.status == "open"
+    assert len(view.candidates) == 5
+    # candidates sorted by effective_score (score * decay_factor) desc
+    scores = [c.effective_score for c in view.candidates]
+    assert scores == sorted(scores, reverse=True)
+
+
+async def test_rank_batch_records_operator_order(db_pool):
+    svc = TopicBatchService(db_pool)
+    await svc.rank_batch(batch_id=BATCH_ID, ordered_candidate_ids=["c5","c1","c3","c2","c4"])
+    view = await svc.show_batch(batch_id=BATCH_ID)
+    assert [c.id for c in sorted(view.candidates, key=lambda x: x.operator_rank)] == \
+        ["c5","c1","c3","c2","c4"]
+
+
+async def test_edit_winner_sets_operator_edit_fields(db_pool):
+    svc = TopicBatchService(db_pool)
+    await svc.edit_winner(batch_id=BATCH_ID, topic="New Title", angle="Fresh angle")
+    view = await svc.show_batch(batch_id=BATCH_ID)
+    winner = [c for c in view.candidates if c.operator_rank == 1][0]
+    assert winner.operator_edited_topic == "New Title"
+    assert winner.operator_edited_angle == "Fresh angle"
+
+
+async def test_resolve_batch_advances_winner_and_marks_resolved(db_pool, monkeypatch):
+    # Monkeypatch the pipeline handoff so the test doesn't need a real worker
+    handoff_calls = []
+    async def fake_handoff(candidate, niche):
+        handoff_calls.append((candidate.id, niche.slug))
+    monkeypatch.setattr(
+        "services.topic_batch_service.TopicBatchService._handoff_to_pipeline",
+        fake_handoff,
+    )
+    svc = TopicBatchService(db_pool)
+    await svc.resolve_batch(batch_id=BATCH_ID)
+    view = await svc.show_batch(batch_id=BATCH_ID)
+    assert view.status == "resolved"
+    assert view.picked_candidate_id is not None
+    assert len(handoff_calls) == 1
+
+
+async def test_reject_batch_marks_expired_and_can_re-discover(db_pool):
+    svc = TopicBatchService(db_pool)
+    await svc.reject_batch(batch_id=BATCH_ID, reason="none of these")
+    view = await svc.show_batch(batch_id=BATCH_ID)
+    assert view.status == "expired"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Expected: AttributeError on missing methods.
+
+- [ ] **Step 3: Implement the operator-interaction methods**
+
+Add to `TopicBatchService`:
+
+```python
+@dataclass
+class CandidateView:
+    id: str
+    kind: str           # 'external' | 'internal'
+    title: str
+    summary: str | None
+    score: float
+    decay_factor: float
+    effective_score: float
+    rank_in_batch: int
+    operator_rank: int | None
+    operator_edited_topic: str | None
+    operator_edited_angle: str | None
+    score_breakdown: dict[str, float]
+
+
+@dataclass
+class BatchView:
+    id: UUID
+    niche_id: UUID
+    status: str
+    picked_candidate_id: UUID | None
+    candidates: list[CandidateView]
+
+
+async def show_batch(self, *, batch_id: UUID) -> BatchView:
+    async with self._pool.acquire() as conn:
+        batch = await conn.fetchrow("SELECT * FROM topic_batches WHERE id = $1", batch_id)
+        if not batch:
+            raise ValueError(f"unknown batch_id: {batch_id}")
+        ext = await conn.fetch("SELECT * FROM topic_candidates WHERE batch_id = $1", batch_id)
+        intern = await conn.fetch("SELECT * FROM internal_topic_candidates WHERE batch_id = $1", batch_id)
+    cands: list[CandidateView] = []
+    for r in ext:
+        score = float(r["score"]); df = float(r["decay_factor"])
+        cands.append(CandidateView(
+            id=str(r["id"]), kind="external", title=r["title"], summary=r["summary"],
+            score=score, decay_factor=df, effective_score=score * df,
+            rank_in_batch=r["rank_in_batch"], operator_rank=r["operator_rank"],
+            operator_edited_topic=r["operator_edited_topic"],
+            operator_edited_angle=r["operator_edited_angle"],
+            score_breakdown=r["score_breakdown"] or {},
+        ))
+    for r in intern:
+        score = float(r["score"]); df = float(r["decay_factor"])
+        cands.append(CandidateView(
+            id=str(r["id"]), kind="internal", title=r["distilled_topic"], summary=r["distilled_angle"],
+            score=score, decay_factor=df, effective_score=score * df,
+            rank_in_batch=r["rank_in_batch"], operator_rank=r["operator_rank"],
+            operator_edited_topic=r["operator_edited_topic"],
+            operator_edited_angle=r["operator_edited_angle"],
+            score_breakdown=r["score_breakdown"] or {},
+        ))
+    cands.sort(key=lambda c: -c.effective_score)
+    return BatchView(
+        id=batch["id"], niche_id=batch["niche_id"], status=batch["status"],
+        picked_candidate_id=batch["picked_candidate_id"],
+        candidates=cands,
+    )
+
+
+async def rank_batch(self, *, batch_id: UUID, ordered_candidate_ids: list[str]) -> None:
+    """Set operator_rank on each candidate to its 1-based position in the list."""
+    async with self._pool.acquire() as conn:
+        async with conn.transaction():
+            for rank, cand_id in enumerate(ordered_candidate_ids, start=1):
+                # Try external first, then internal
+                updated = await conn.execute(
+                    "UPDATE topic_candidates SET operator_rank = $1 WHERE id = $2 AND batch_id = $3",
+                    rank, cand_id, batch_id,
+                )
+                if updated.endswith("0"):
+                    await conn.execute(
+                        "UPDATE internal_topic_candidates SET operator_rank = $1 WHERE id = $2 AND batch_id = $3",
+                        rank, cand_id, batch_id,
+                    )
+
+
+async def edit_winner(self, *, batch_id: UUID, topic: str | None = None, angle: str | None = None) -> None:
+    """Edit the candidate currently ranked #1 by the operator."""
+    async with self._pool.acquire() as conn:
+        # Find the rank-1 candidate
+        rid = await conn.fetchval(
+            "SELECT id FROM topic_candidates WHERE batch_id = $1 AND operator_rank = 1",
+            batch_id,
+        )
+        kind = "external"
+        if rid is None:
+            rid = await conn.fetchval(
+                "SELECT id FROM internal_topic_candidates WHERE batch_id = $1 AND operator_rank = 1",
+                batch_id,
+            )
+            kind = "internal"
+        if rid is None:
+            raise ValueError(f"no rank-1 candidate in batch {batch_id}; rank first")
+        tbl = "topic_candidates" if kind == "external" else "internal_topic_candidates"
+        await conn.execute(
+            f"UPDATE {tbl} SET operator_edited_topic = $1, operator_edited_angle = $2 WHERE id = $3",
+            topic, angle, rid,
+        )
+
+
+async def resolve_batch(self, *, batch_id: UUID) -> None:
+    """Resolve = mark batch resolved, set picked_candidate_id to operator_rank=1,
+    advance that candidate to the existing pipeline."""
+    view = await self.show_batch(batch_id=batch_id)
+    winner = next((c for c in view.candidates if c.operator_rank == 1), None)
+    if winner is None:
+        raise ValueError("no operator_rank=1 candidate; rank first")
+    niche = await self._niche_svc.get_by_id(view.niche_id)
+    await self._handoff_to_pipeline(winner, niche)
+    async with self._pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE topic_batches
+               SET status='resolved', resolved_at=NOW(),
+                   picked_candidate_id=$1, picked_candidate_kind=$2
+             WHERE id=$3
+            """,
+            winner.id, winner.kind, batch_id,
+        )
+
+
+async def reject_batch(self, *, batch_id: UUID, reason: str = "") -> None:
+    async with self._pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE topic_batches SET status='expired', resolved_at=NOW() WHERE id=$1",
+            batch_id,
+        )
+    logger.info("Batch %s rejected (reason=%r)", batch_id, reason)
+
+
+async def _handoff_to_pipeline(self, winner: "CandidateView", niche: Niche) -> None:
+    """Advance the winning candidate into the existing content pipeline.
+    Creates a new content_task with topic + angle + niche + writer_rag_mode +
+    topic_batch_id provenance.
+    """
+    topic = winner.operator_edited_topic or winner.title
+    angle = winner.operator_edited_angle or winner.summary or ""
+    async with self._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO content_tasks
+              (topic, description, status, stage, niche_slug, writer_rag_mode, topic_batch_id)
+            VALUES ($1, $2, 'pending', 'pending', $3, $4, $5)
+            """,
+            topic, angle, niche.slug, niche.writer_rag_mode,
+            winner.id,  # batch id provenance — note: column is topic_batch_id, see Task 8
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/test_topic_batch_service.py -v
+```
+
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/topic_batch_service.py src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
+git commit -m "feat(topics): operator interactions — show / rank / edit / resolve / reject"
+```
+
+---
+
+## Task 8: Pipeline handoff schema — content_tasks columns
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/migrations/<NEXT+2>_extend_content_tasks_for_niches.py`
+
+`content_tasks` needs three new columns the handoff writes to: `niche_slug`, `writer_rag_mode`, `topic_batch_id`.
+
+- [ ] **Step 1: Create the migration**
+
+```python
+"""Migration <NEXT+2>: extend content_tasks for niche-aware pipeline handoff.
+
+Adds three columns the new TopicBatchService.handoff path writes:
+- niche_slug         (which niche the task belongs to)
+- writer_rag_mode    (the writer mode the writer dispatcher reads)
+- topic_batch_id     (provenance pointer to the batch the topic came from)
+
+All nullable for backward compat — existing tasks predate niches and stay valid.
+"""
+
+from services.logger_config import get_logger
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            ALTER TABLE content_tasks
+              ADD COLUMN IF NOT EXISTS niche_slug TEXT,
+              ADD COLUMN IF NOT EXISTS writer_rag_mode TEXT
+                CHECK (writer_rag_mode IN ('TOPIC_ONLY','CITATION_BUDGET','STORY_SPINE','TWO_PASS') OR writer_rag_mode IS NULL),
+              ADD COLUMN IF NOT EXISTS topic_batch_id UUID REFERENCES topic_batches(id)
+        """)
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS ix_content_tasks_niche ON content_tasks(niche_slug) WHERE niche_slug IS NOT NULL"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS ix_content_tasks_batch ON content_tasks(topic_batch_id) WHERE topic_batch_id IS NOT NULL"
+        )
+        logger.info("Extended content_tasks with niche columns")
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("DROP INDEX IF EXISTS ix_content_tasks_batch")
+        await conn.execute("DROP INDEX IF EXISTS ix_content_tasks_niche")
+        await conn.execute("""
+            ALTER TABLE content_tasks
+              DROP COLUMN IF EXISTS topic_batch_id,
+              DROP COLUMN IF EXISTS writer_rag_mode,
+              DROP COLUMN IF EXISTS niche_slug
+        """)
+```
+
+- [ ] **Step 2: Run migrations smoke**
+
+```bash
+python scripts/ci/migrations_smoke.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cofounder_agent/services/migrations/<NEXT+2>_extend_content_tasks_for_niches.py
+git commit -m "feat(pipeline): extend content_tasks for niche-aware handoff"
+```
+
+---
+
+## Task 9: Writer mode dispatcher
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/writer_rag_modes/__init__.py`
+- Test: `src/cofounder_agent/tests/unit/services/writer_rag_modes/test_modes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/services/writer_rag_modes/test_modes.py
+import pytest
+from unittest.mock import AsyncMock
+from services.writer_rag_modes import dispatch_writer_mode
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_dispatch_calls_topic_only_handler(monkeypatch):
+    called = {}
+    async def fake_handler(*, topic, angle, niche_id, pool, **kw):
+        called["mode"] = "TOPIC_ONLY"
+        return {"draft": "..."}
+    monkeypatch.setattr("services.writer_rag_modes.topic_only.run", fake_handler)
+    out = await dispatch_writer_mode(
+        mode="TOPIC_ONLY", topic="t", angle="a", niche_id="n", pool=None,
+    )
+    assert called["mode"] == "TOPIC_ONLY"
+    assert "draft" in out
+
+
+async def test_dispatch_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown writer_rag_mode"):
+        await dispatch_writer_mode(mode="BOGUS", topic="t", angle="a", niche_id="n", pool=None)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+```python
+# services/writer_rag_modes/__init__.py
+"""Writer RAG mode dispatcher.
+
+The writer stage of the content pipeline delegates to one of four handlers
+based on the niche's writer_rag_mode setting. Each handler produces a draft
+with different RAG strategy.
+"""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+
+
+async def dispatch_writer_mode(
+    *,
+    mode: str,
+    topic: str,
+    angle: str,
+    niche_id: UUID | str,
+    pool,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Route the writer call to the right mode handler. Each handler returns
+    the writer's output dict (at minimum {"draft": "..."} plus any metadata).
+    """
+    if mode == "TOPIC_ONLY":
+        from services.writer_rag_modes import topic_only
+        return await topic_only.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "CITATION_BUDGET":
+        from services.writer_rag_modes import citation_budget
+        return await citation_budget.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "STORY_SPINE":
+        from services.writer_rag_modes import story_spine
+        return await story_spine.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "TWO_PASS":
+        from services.writer_rag_modes import two_pass
+        return await two_pass.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    else:
+        raise ValueError(f"unknown writer_rag_mode: {mode!r}")
+```
+
+- [ ] **Step 4: Run to verify (the unknown-mode test passes; topic_only test still fails because the module doesn't exist yet — that's covered in Task 10)**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/writer_rag_modes/test_modes.py::test_dispatch_unknown_mode_raises -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/writer_rag_modes/__init__.py src/cofounder_agent/tests/unit/services/writer_rag_modes/test_modes.py
+git commit -m "feat(writer): writer_rag_mode dispatcher (4-mode router)"
+```
+
+---
+
+## Task 10: Writer mode — TOPIC_ONLY
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/writer_rag_modes/topic_only.py`
+
+- [ ] **Step 1: Implement TOPIC_ONLY**
+
+```python
+# services/writer_rag_modes/topic_only.py
+"""TOPIC_ONLY writer mode — single embedding query, dump top-N internal snippets
+into the writer prompt as background context. Simplest mode."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    from services.embedding_service import embed_text
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        # Top 8 internal snippets by cosine similarity. Uses pgvector.
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview,
+                   1 - (embedding <=> $1::vector) AS similarity
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 8
+            """,
+            qvec,
+        )
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]),
+                 "snippet": r["text_preview"], "similarity": float(r["similarity"])}
+                for r in rows]
+    # Hand off to the existing writer with the snippets in the prompt context.
+    from services.ai_content_generator import generate_with_context
+    draft = await generate_with_context(topic=topic, angle=angle, snippets=snippets)
+    return {"draft": draft, "snippets_used": snippets, "mode": "TOPIC_ONLY"}
+```
+
+- [ ] **Step 2: Run dispatcher test (it should now pass for TOPIC_ONLY)**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/writer_rag_modes/test_modes.py -v
+```
+
+Expected: 2 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cofounder_agent/services/writer_rag_modes/topic_only.py
+git commit -m "feat(writer): TOPIC_ONLY mode — single RAG query, snippets in prompt"
+```
+
+---
+
+## Task 11: Writer mode — CITATION_BUDGET
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/writer_rag_modes/citation_budget.py`
+
+- [ ] **Step 1: Implement CITATION_BUDGET**
+
+```python
+# services/writer_rag_modes/citation_budget.py
+"""CITATION_BUDGET — same as TOPIC_ONLY but the writer is REQUIRED to cite
+at least N internal sources. content_validator enforces post-write."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_MIN_CITATIONS = 3
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool,
+              min_citations: int = DEFAULT_MIN_CITATIONS, **kw: Any) -> dict[str, Any]:
+    from services.embedding_service import embed_text
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 12
+            """,
+            qvec,
+        )
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
+                for r in rows]
+
+    citation_instruction = (
+        f"You MUST cite at least {min_citations} of the provided internal sources by their "
+        f"source/ref pair (e.g. [claude_sessions/abc123]). Failing to cite that many will "
+        f"cause the post to be rejected by the validator."
+    )
+    from services.ai_content_generator import generate_with_context
+    draft = await generate_with_context(
+        topic=topic, angle=angle, snippets=snippets,
+        extra_instructions=citation_instruction,
+    )
+    # Implementer wires content_validator extension to count [source/ref] tokens
+    # in the draft and reject if < min_citations. Extension can be follow-up.
+    return {"draft": draft, "snippets_used": snippets, "min_citations": min_citations, "mode": "CITATION_BUDGET"}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/cofounder_agent/services/writer_rag_modes/citation_budget.py
+git commit -m "feat(writer): CITATION_BUDGET mode — required N internal citations"
+```
+
+---
+
+## Task 12: Writer mode — STORY_SPINE
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/writer_rag_modes/story_spine.py`
+
+- [ ] **Step 1: Implement STORY_SPINE**
+
+```python
+# services/writer_rag_modes/story_spine.py
+"""STORY_SPINE — preprocess top snippets into a structured outline with one
+LLM call, then expand the outline to full prose with the writer."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    from services.embedding_service import embed_text
+    from services.topic_ranking import _ollama_chat_json
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 15
+            """,
+            qvec,
+        )
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
+                for r in rows]
+    snippet_block = "\n---\n".join(s["snippet"][:600] for s in snippets if s["snippet"])
+
+    spine_prompt = f"""Read these 15 snippets from an AI-operated content business's records.
+Produce a structured outline for a blog post about: "{topic}" (angle: "{angle}").
+
+Outline format (return JSON):
+{{
+  "hook": "<opening hook, one sentence>",
+  "what_happened": "<the timeline of events as drawn from snippets>",
+  "why_it_matters": "<the lesson or insight>",
+  "what_we_learned": "<concrete takeaways>",
+  "close": "<call-to-action or final framing>"
+}}
+
+Snippets:
+{snippet_block}
+"""
+    spine_raw = await _ollama_chat_json(spine_prompt, model="glm-4.7-5090:latest")
+    import json
+    spine = json.loads(spine_raw)
+
+    from services.ai_content_generator import generate_with_outline
+    draft = await generate_with_outline(topic=topic, outline=spine, snippets=snippets)
+    return {"draft": draft, "spine": spine, "snippets_used": snippets, "mode": "STORY_SPINE"}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/cofounder_agent/services/writer_rag_modes/story_spine.py
+git commit -m "feat(writer): STORY_SPINE mode — structured outline pre-pass"
+```
+
+---
+
+## Task 13: Writer mode — TWO_PASS (Glad Labs default)
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/writer_rag_modes/two_pass.py`
+
+- [ ] **Step 1: Implement TWO_PASS**
+
+```python
+# services/writer_rag_modes/two_pass.py
+"""TWO_PASS — first draft from internal context only (no external research),
+then a fact-augmentation pass adds external corroboration where needed.
+
+Glad Labs default: maximum first-person reporting; external content only
+appears where the model identifies a claim that needs outside support."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    from services.embedding_service import embed_text
+    from services.topic_ranking import _ollama_chat_json
+    from services.ai_content_generator import generate_with_context
+
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 20
+            """,
+            qvec,
+        )
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
+                for r in rows]
+
+    # Pass 1 — internal-only draft
+    pass1_instruction = (
+        "Write a first-draft blog post drawing ONLY from the provided internal snippets. "
+        "Do NOT make up external facts, statistics, or quotes you cannot ground in a snippet. "
+        "If you need an outside fact you don't have, mark it [EXTERNAL_NEEDED: <description>] "
+        "in the draft so a follow-up pass can fill it in."
+    )
+    pass1_draft = await generate_with_context(
+        topic=topic, angle=angle, snippets=snippets,
+        extra_instructions=pass1_instruction,
+    )
+
+    # Find [EXTERNAL_NEEDED: ...] markers
+    import re
+    needs = re.findall(r"\[EXTERNAL_NEEDED:\s*([^\]]+)\]", pass1_draft)
+    if not needs:
+        return {"draft": pass1_draft, "snippets_used": snippets,
+                "external_lookups": [], "mode": "TWO_PASS"}
+
+    # Pass 2 — external fact-augmentation
+    from services.research_service import research_topic
+    augmentations = []
+    for need in needs:
+        aug = await research_topic(query=need.strip(), max_sources=2)
+        augmentations.append({"need": need.strip(), "research": aug})
+
+    aug_block = "\n\n".join(f"[EXTERNAL_NEEDED: {a['need']}] → {a['research']}" for a in augmentations)
+    revise_prompt = f"""Revise the following draft. For each [EXTERNAL_NEEDED: ...] marker,
+substitute the corresponding external fact provided below. Keep the rest unchanged.
+
+Original draft:
+{pass1_draft}
+
+External facts:
+{aug_block}
+"""
+    final_draft = await _ollama_chat_json(revise_prompt, model="glm-4.7-5090:latest")
+    return {
+        "draft": final_draft, "pass1_draft": pass1_draft,
+        "snippets_used": snippets, "external_lookups": augmentations,
+        "mode": "TWO_PASS",
+    }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/cofounder_agent/services/writer_rag_modes/two_pass.py
+git commit -m "feat(writer): TWO_PASS mode — internal-first + external fact-augmentation"
+```
+
+---
+
+## Task 14: Wire writer dispatch into ai_content_generator
+
+**Files:**
+
+- Modify: `src/cofounder_agent/services/ai_content_generator.py`
+
+- [ ] **Step 1: Locate the writer entry point**
+
+```bash
+grep -n "def generate" src/cofounder_agent/services/ai_content_generator.py | head
+```
+
+The implementer reads the existing entry point (likely `generate_blog_post` or similar) and identifies where to inject the dispatch.
+
+- [ ] **Step 2: Add helper functions the writer modes call into**
+
+The writer modes call `generate_with_context(topic, angle, snippets, extra_instructions=)` and `generate_with_outline(topic, outline, snippets)`. These need to exist on `ai_content_generator`. If they don't, the implementer adds thin wrappers that compose the existing prompt-building helpers with the new arguments.
+
+```python
+# Append to services/ai_content_generator.py
+
+async def generate_with_context(
+    *, topic: str, angle: str, snippets: list[dict],
+    extra_instructions: str | None = None,
+) -> str:
+    """Build a prompt using the snippets as background context, generate the draft.
+    Wraps the existing generation path; tests can monkeypatch here.
+    """
+    snippet_block = "\n".join(
+        f"[{s['source']}/{s['ref']}] {s['snippet'][:500]}"
+        for s in snippets if s.get('snippet')
+    )
+    instructions = extra_instructions or ""
+    # Implementer plugs into the existing prompt builder + Ollama call here.
+    # Below is the minimal shape:
+    from services.topic_ranking import _ollama_chat_json
+    prompt = f"""Write a blog post on the topic: "{topic}" with this angle: "{angle}".
+
+{instructions}
+
+Background context (cite where relevant):
+{snippet_block}
+
+Return the full post body in Markdown.
+"""
+    return await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+
+
+async def generate_with_outline(
+    *, topic: str, outline: dict, snippets: list[dict],
+) -> str:
+    snippet_block = "\n".join(
+        f"[{s['source']}/{s['ref']}] {s['snippet'][:500]}"
+        for s in snippets if s.get('snippet')
+    )
+    outline_block = "\n".join(f"{k.replace('_',' ').title()}: {v}" for k, v in outline.items())
+    from services.topic_ranking import _ollama_chat_json
+    prompt = f"""Expand the following outline into a full blog post.
+
+Topic: {topic}
+Outline:
+{outline_block}
+
+Background snippets to draw on:
+{snippet_block}
+
+Return the full post body in Markdown.
+"""
+    return await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+```
+
+- [ ] **Step 3: Modify the writer pipeline stage to call the dispatcher**
+
+Find the existing writer stage (probably `services/stages/generate_content.py` or similar). The implementer adds:
+
+```python
+# In the writer stage, after loading the content_task row
+from services.writer_rag_modes import dispatch_writer_mode
+
+if task.writer_rag_mode and task.writer_rag_mode != "":
+    # New niche-aware path
+    result = await dispatch_writer_mode(
+        mode=task.writer_rag_mode,
+        topic=task.topic,
+        angle=task.description or "",
+        niche_id=None,  # implementer wires niche_id lookup if needed
+        pool=pool,
+    )
+    draft = result["draft"]
+else:
+    # Legacy path — existing generation logic unchanged
+    draft = await legacy_generate_blog_post(task)
+```
+
+- [ ] **Step 4: Smoke test by creating a content_task with writer_rag_mode set**
+
+Manual verification — start the worker, insert a row with `writer_rag_mode='TOPIC_ONLY'`, watch logs to confirm the dispatch fires.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cofounder_agent/services/ai_content_generator.py
+# plus the writer-stage file you modified
+git commit -m "feat(writer): wire writer_rag_mode dispatch into generation stage"
+```
+
+---
+
+## Task 15: CLI commands — topics + niche
+
+**Files:**
+
+- Modify: `src/cofounder_agent/poindexter/cli/topics.py`
+
+- [ ] **Step 1: Read the existing CLI structure**
+
+```bash
+sed -n '1,40p' src/cofounder_agent/poindexter/cli/topics.py
+```
+
+The implementer mirrors the existing click command pattern (already used by `auth.py`, `stores.py`, etc — see Task 17 of OAuth Phase 1 PR #250 for a template).
+
+- [ ] **Step 2: Add the new commands**
+
+```python
+# Append to poindexter/cli/topics.py
+
+import click, asyncio, json
+from poindexter.cli._dsn import _dsn  # existing helper
+
+
+@topics_group.command("show-batch")
+@click.option("--niche", required=True, help="Niche slug.")
+def show_batch(niche: str) -> None:
+    """Show the current open batch for a niche."""
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+        from services.topic_batch_service import TopicBatchService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            n = await NicheService(pool).get_by_slug(niche)
+            if not n: raise click.ClickException(f"unknown niche: {niche}")
+            async with pool.acquire() as conn:
+                bid = await conn.fetchval(
+                    "SELECT id FROM topic_batches WHERE niche_id = $1 AND status = 'open'",
+                    n.id,
+                )
+            if bid is None:
+                click.echo(f"No open batch for niche {niche}.")
+                return
+            view = await TopicBatchService(pool).show_batch(batch_id=bid)
+            click.echo(f"Batch {view.id} (status={view.status})")
+            for c in view.candidates:
+                marker = f"#{c.operator_rank}" if c.operator_rank else f"sys#{c.rank_in_batch}"
+                click.echo(f"  {marker:6s} [{c.kind:8s}] eff={c.effective_score:5.1f} — {c.title}")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@topics_group.command("rank-batch")
+@click.argument("batch_id")
+@click.option("--order", required=True, help="Comma-separated candidate ids in your preferred order, best-first.")
+def rank_batch(batch_id: str, order: str) -> None:
+    """Set operator ranking for a batch's candidates."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+        ids = [s.strip() for s in order.split(",") if s.strip()]
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).rank_batch(batch_id=batch_id, ordered_candidate_ids=ids)
+            click.echo(f"Ranked {len(ids)} candidates in batch {batch_id}")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@topics_group.command("edit-winner")
+@click.argument("batch_id")
+@click.option("--topic", help="Override the winner's title.")
+@click.option("--angle", help="Override the winner's angle/summary.")
+def edit_winner(batch_id: str, topic: str | None, angle: str | None) -> None:
+    """Edit the title/angle of the rank-1 candidate before resolution."""
+    if not topic and not angle:
+        raise click.UsageError("Provide --topic and/or --angle.")
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).edit_winner(batch_id=batch_id, topic=topic, angle=angle)
+            click.echo("Edited winner.")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@topics_group.command("resolve-batch")
+@click.argument("batch_id")
+def resolve_batch(batch_id: str) -> None:
+    """Resolve a batch — advance the rank-1 candidate to the pipeline."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).resolve_batch(batch_id=batch_id)
+            click.echo(f"Resolved {batch_id}")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@topics_group.command("reject-batch")
+@click.argument("batch_id")
+@click.option("--reason", default="", help="Optional reason text.")
+def reject_batch(batch_id: str, reason: str) -> None:
+    """Reject a batch — discard candidates, allow a fresh sweep."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).reject_batch(batch_id=batch_id, reason=reason)
+            click.echo(f"Rejected {batch_id}")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@topics_group.group("niche")
+def niche_group():
+    """Manage niche configurations."""
+    pass
+
+
+@niche_group.command("list")
+def niche_list():
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            for n in await NicheService(pool).list_active():
+                click.echo(f"{n.slug:20s} {n.name:30s} mode={n.writer_rag_mode}")
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+
+
+@niche_group.command("show")
+@click.argument("slug")
+def niche_show(slug: str):
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            svc = NicheService(pool)
+            n = await svc.get_by_slug(slug)
+            if not n: raise click.ClickException(f"unknown niche: {slug}")
+            click.echo(json.dumps({
+                "slug": n.slug, "name": n.name, "active": n.active,
+                "writer_rag_mode": n.writer_rag_mode, "batch_size": n.batch_size,
+                "discovery_cadence_minute_floor": n.discovery_cadence_minute_floor,
+                "audience_tags": n.target_audience_tags,
+                "goals": [{"type": g.goal_type, "weight": g.weight_pct}
+                          for g in await svc.get_goals(n.id)],
+                "sources": [{"name": s.source_name, "enabled": s.enabled, "weight": s.weight_pct}
+                            for s in await svc.get_sources(n.id)],
+            }, indent=2))
+        finally:
+            await pool.close()
+    asyncio.run(_impl())
+```
+
+- [ ] **Step 3: Sanity-check the CLI loads**
+
+```bash
+DATABASE_URL="$(python -c 'import sys; sys.path.insert(0,"."); from brain.bootstrap import resolve_database_url; print(resolve_database_url())')" \
+  poindexter topics --help
+```
+
+Expected: new commands appear in the help output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cofounder_agent/poindexter/cli/topics.py
+git commit -m "feat(cli): topics show-batch / rank-batch / edit-winner / resolve-batch / reject-batch + niche subgroup"
+```
+
+---
+
+## Task 16: MCP tools mirroring the CLI
+
+**Files:**
+
+- Modify: `mcp-server/server.py`
+
+- [ ] **Step 1: Read the existing MCP tool pattern**
+
+```bash
+grep -nB 1 "@mcp.tool()" mcp-server/server.py | head -30
+```
+
+- [ ] **Step 2: Add MCP tools (mirror CLI commands)**
+
+```python
+# Append to mcp-server/server.py
+
+@mcp.tool()
+async def topics_show_batch(niche: str) -> str:
+    """Show the current open batch for a niche, sorted by effective_score."""
+    try:
+        pool = await _get_pool()
+        from services.niche_service import NicheService
+        from services.topic_batch_service import TopicBatchService
+        n = await NicheService(pool).get_by_slug(niche)
+        if not n: return f"unknown niche: {niche}"
+        async with pool.acquire() as conn:
+            bid = await conn.fetchval(
+                "SELECT id FROM topic_batches WHERE niche_id = $1 AND status = 'open'",
+                n.id,
+            )
+        if bid is None: return f"No open batch for niche {niche}."
+        view = await TopicBatchService(pool).show_batch(batch_id=bid)
+        lines = [f"Batch {view.id} (status={view.status}, niche={niche})"]
+        for c in view.candidates:
+            marker = f"#{c.operator_rank}" if c.operator_rank else f"sys#{c.rank_in_batch}"
+            lines.append(f"  {marker:6s} [{c.kind:8s}] eff={c.effective_score:5.1f} | {c.id} | {c.title}")
+        return "\n".join(lines)
+    except Exception as e:
+        return _format_tool_error("topics_show_batch", e)
+
+
+@mcp.tool()
+async def topics_rank_batch(batch_id: str, ordered_candidate_ids: list[str]) -> str:
+    """Set operator ranking for a batch's candidates. Pass IDs in best-first order."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).rank_batch(
+            batch_id=batch_id, ordered_candidate_ids=ordered_candidate_ids,
+        )
+        return f"Ranked {len(ordered_candidate_ids)} candidates in batch {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_rank_batch", e)
+
+
+@mcp.tool()
+async def topics_edit_winner(batch_id: str, topic: str = "", angle: str = "") -> str:
+    """Edit the title/angle of the rank-1 candidate before resolution."""
+    if not topic and not angle:
+        return "topics_edit_winner failed: provide topic and/or angle"
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).edit_winner(
+            batch_id=batch_id,
+            topic=topic or None, angle=angle or None,
+        )
+        return "Edited winner."
+    except Exception as e:
+        return _format_tool_error("topics_edit_winner", e)
+
+
+@mcp.tool()
+async def topics_resolve_batch(batch_id: str) -> str:
+    """Resolve a batch — advance the rank-1 candidate into the content pipeline."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).resolve_batch(batch_id=batch_id)
+        return f"Resolved {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_resolve_batch", e)
+
+
+@mcp.tool()
+async def topics_reject_batch(batch_id: str, reason: str = "") -> str:
+    """Reject a batch — discard candidates, allow a fresh sweep."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).reject_batch(batch_id=batch_id, reason=reason)
+        return f"Rejected {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_reject_batch", e)
+```
+
+`_format_tool_error` already exists from PR #262 (#259 fix). Reuse it.
+
+- [ ] **Step 3: Smoke test**
+
+Restart the MCP HTTP server, call one of the new tools via the connector, confirm output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mcp-server/server.py
+git commit -m "feat(mcp): topics_show_batch / rank_batch / edit_winner / resolve_batch / reject_batch tools"
+```
+
+---
+
+## Task 17: Seed Glad Labs as the first niche
+
+**Files:**
+
+- Create: `src/cofounder_agent/services/migrations/<NEXT+3>_seed_glad_labs_niche.py`
+
+- [ ] **Step 1: Create the seed migration**
+
+```python
+"""Migration <NEXT+3>: seed Glad Labs as the first configured niche.
+
+Uses TWO_PASS writer mode (per spec — Glad Labs is the primary-source niche
+where we lean hardest on internal RAG context). Goals are the operator's
+opening guesses; tune later via the CLI.
+"""
+
+from services.logger_config import get_logger
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        existing = await conn.fetchval("SELECT id FROM niches WHERE slug = 'glad-labs'")
+        if existing is not None:
+            logger.info("Glad Labs niche already exists (id=%s) — skipping seed", existing)
+            return
+
+        niche_id = await conn.fetchval(
+            """
+            INSERT INTO niches (slug, name, target_audience_tags,
+                                writer_rag_mode, batch_size,
+                                discovery_cadence_minute_floor)
+            VALUES ('glad-labs', 'Glad Labs',
+                    ARRAY['indie-devs','ai-curious','prospects','future-matt'],
+                    'TWO_PASS', 5, 60)
+            RETURNING id
+            """,
+        )
+
+        # Goals (sum to 100)
+        goals = [
+            ("AUTHORITY", 35),  # show what we actually know
+            ("EDUCATION", 25),  # teach the reader
+            ("BRAND",     20),  # reinforce the Glad Labs voice
+            ("TRAFFIC",   15),  # not nothing, but not the driver
+            ("REVENUE",    5),  # eventually
+        ]
+        for goal_type, weight in goals:
+            await conn.execute(
+                "INSERT INTO niche_goals (niche_id, goal_type, weight_pct) VALUES ($1, $2, $3)",
+                niche_id, goal_type, weight,
+            )
+
+        # Sources — internal_rag is the lead, plus the existing external feeds
+        sources = [
+            ("internal_rag", True, 50),
+            ("hackernews",   True, 20),
+            ("devto",        True, 15),
+            ("web_search",   True, 10),
+            ("knowledge",    True,  5),
+        ]
+        for name, enabled, weight in sources:
+            await conn.execute(
+                "INSERT INTO niche_sources (niche_id, source_name, enabled, weight_pct) VALUES ($1, $2, $3, $4)",
+                niche_id, name, enabled, weight,
+            )
+        logger.info("Seeded Glad Labs niche (id=%s)", niche_id)
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM niches WHERE slug = 'glad-labs'")
+        logger.info("Removed Glad Labs niche seed")
+```
+
+- [ ] **Step 2: Verify the seed via CLI**
+
+```bash
+DATABASE_URL="$(python -c 'import sys; sys.path.insert(0,"."); from brain.bootstrap import resolve_database_url; print(resolve_database_url())')" \
+  poindexter topics niche show glad-labs
+```
+
+Expected: prints the JSON config.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cofounder_agent/services/migrations/<NEXT+3>_seed_glad_labs_niche.py
+git commit -m "feat(niche): seed Glad Labs as the first niche (TWO_PASS, 5 goals, 5 sources)"
+```
+
+---
+
+## Task 18: End-to-end integration test + smoke run
+
+**Files:**
+
+- Create: `src/cofounder_agent/tests/integration/test_niche_discovery_e2e.py`
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+# tests/integration/test_niche_discovery_e2e.py
+"""Integration: run a full niche discovery sweep against a live DB,
+expect a topic_batch with operator-actionable candidates."""
+
+import pytest
+from services.niche_service import NicheService
+from services.topic_batch_service import TopicBatchService
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def test_glad_labs_sweep_produces_a_batch(db_pool):
+    nsvc = NicheService(db_pool)
+    n = await nsvc.get_by_slug("glad-labs")
+    assert n is not None, "glad-labs niche should be seeded"
+    batch = await TopicBatchService(db_pool).run_sweep(niche_id=n.id)
+    if batch is None:
+        # floor not elapsed since prior run; force it via the test
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM discovery_runs WHERE niche_id = $1", n.id,
+            )
+        batch = await TopicBatchService(db_pool).run_sweep(niche_id=n.id)
+    assert batch is not None
+    assert batch.status == "open"
+    assert batch.candidate_count >= 1
+
+
+async def test_resolve_advances_to_content_task(db_pool, monkeypatch):
+    """Pick a batch, rank, resolve, expect a content_tasks row exists."""
+    # ... implementer wires this end-to-end test
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/integration/test_niche_discovery_e2e.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Manual smoke**
+
+```bash
+# 1. Trigger a sweep manually (until reactive trigger is wired into a job)
+DATABASE_URL=... poindexter topics niche show glad-labs   # confirm seed
+# 2. Trigger a sweep — wire a CLI command for this if not done; for now, via Python:
+python -c "
+import asyncio, asyncpg, sys
+sys.path.insert(0, '.')
+from brain.bootstrap import resolve_database_url
+from services.topic_batch_service import TopicBatchService
+from services.niche_service import NicheService
+async def go():
+    p = await asyncpg.create_pool(resolve_database_url())
+    nsvc = NicheService(p)
+    n = await nsvc.get_by_slug('glad-labs')
+    batch = await TopicBatchService(p).run_sweep(niche_id=n.id)
+    print('batch:', batch)
+    await p.close()
+asyncio.run(go())
+"
+# 3. Show + rank + resolve
+poindexter topics show-batch --niche glad-labs
+# (copy 5 candidate IDs)
+poindexter topics rank-batch <batch_id> --order id1,id2,id3,id4,id5
+poindexter topics edit-winner <batch_id> --topic "Better Title" --angle "Sharper angle"
+poindexter topics resolve-batch <batch_id>
+# 4. Verify a content_task was created
+poindexter tasks list | head
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cofounder_agent/tests/integration/test_niche_discovery_e2e.py
+git commit -m "test(niche): integration e2e — sweep produces batch, resolve advances task"
+```
+
+---
+
+## Task 19: Deprecate topic_proposal_service
+
+**Files:**
+
+- Modify: `src/cofounder_agent/services/topic_proposal_service.py`
+
+- [ ] **Step 1: Add deprecation banner + redirect**
+
+```python
+# At the top of services/topic_proposal_service.py, replace the module docstring with:
+
+"""topic_proposal_service — DEPRECATED as of <NEXT_MIGRATION date>.
+
+Replaced by services.topic_batch_service.TopicBatchService for the
+niche-aware ranked-batch flow (see docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).
+
+Existing callers should migrate to TopicBatchService:
+- propose_topic(...) → TopicBatchService.run_sweep(niche_id=...)
+- approve_topic(...) → TopicBatchService.resolve_batch(batch_id=...)
+- reject_topic(...) → TopicBatchService.reject_batch(batch_id=...)
+
+This module will be deleted in a follow-up PR after the new service has
+been live for one observation window.
+"""
+
+import warnings
+warnings.warn(
+    "services.topic_proposal_service is deprecated — use services.topic_batch_service",
+    DeprecationWarning,
+    stacklevel=2,
+)
+```
+
+- [ ] **Step 2: Identify callers**
+
+```bash
+grep -rn "topic_proposal_service" src/cofounder_agent --include="*.py" | grep -v "topic_proposal_service.py:" | head
+```
+
+The implementer flags each caller in a TODO comment and creates a follow-up GH issue tracking the cleanup.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cofounder_agent/services/topic_proposal_service.py
+git commit -m "chore(deprecate): mark topic_proposal_service as deprecated; replaced by topic_batch_service"
+```
+
+---
+
+## Task 20: Open the PR
+
+**Files:**
+
+- None (workflow only)
+
+- [ ] **Step 1: Push to gitea + github (using the github/main cherry-pick workflow)**
+
+Per CLAUDE.md and the lessons learned in PRs #251/#254/#255/#257: cut from `github/main`, never push the gitea branch directly to github.
+
+```bash
+# Branch was cut from github/main per the pre-flight step. Just push:
+git push -u github feat/niche-topic-discovery
+git push origin feat/niche-topic-discovery
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --repo Glad-Labs/poindexter --base main --head feat/niche-topic-discovery \
+  --title "feat: niche-aware topic discovery + RAG writer pivot" \
+  --body "$(cat <<'EOF'
+Implements docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md.
+
+## Summary
+
+Adds niche-as-config topic discovery with hybrid embed+LLM ranking, batch-of-N operator interaction, and a per-niche writer_rag_mode that pivots the writer from "summarize external content" to "report from internal context." Glad Labs is seeded as the first niche using TWO_PASS mode.
+
+## Tasks shipped
+
+1-2. Schema migrations (niche tables + content_tasks columns)
+3-4. NicheService CRUD
+5. Goal vectors + LLM scorer + decay re-rank
+6. InternalRagSource (RAG-derived candidates)
+7-8. TopicBatchService orchestrator + operator interactions
+9-13. Writer RAG mode dispatcher + 4 mode implementations
+14. Wire dispatch into ai_content_generator
+15-16. CLI + MCP tools
+17. Seed Glad Labs niche
+18. Integration test + smoke
+19. Deprecate topic_proposal_service
+
+## Test plan
+
+- [x] migrations-smoke CI passes (verifies new migrations apply cleanly)
+- [x] All new unit tests pass
+- [x] Integration test creates a batch end-to-end against the live DB
+- [x] Manual smoke: full discover → rank → edit → resolve → content_task creation flow
+
+## Notes
+
+- Old topic_proposal_service deprecated but not deleted — follow-up PR
+- Pipeline gateway caps (separate operator-backpressure feature) explicitly out of scope per spec
+- The 5 spec "Open questions for the implementation plan" are addressed in the per-task notes; the most material decision was using `_ollama_chat_json` indirection so tests can monkeypatch the model call cheaply.
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR file count + leak check**
+
+```bash
+PR_NUM=$(gh pr list --repo Glad-Labs/poindexter --head feat/niche-topic-discovery --json number --jq '.[0].number')
+gh pr view $PR_NUM --repo Glad-Labs/poindexter --json files --jq '.files | length'
+# Expected: well under 100 (target ≤ 25 — this is a big feature but contained to the new files + 3-4 modifications)
+gh pr view $PR_NUM --repo Glad-Labs/poindexter --json files --jq '.files[] | select(.path | test("credentials|matt-profile|shared-context|cms/strapi|agents/content-agent")) | .path'
+# Expected: empty (no leaked private files)
+```
+
+- [ ] **Step 4: Wait for CI + merge**
+
+```bash
+# Wait for migrations-smoke + Mintlify validation to complete:
+until [ "$(gh pr view $PR_NUM --repo Glad-Labs/poindexter --json statusCheckRollup --jq '[.statusCheckRollup[]? | select(.name == "migrations-smoke") | .status][0]')" = "COMPLETED" ]; do sleep 10; done
+
+# Check status:
+gh pr view $PR_NUM --repo Glad-Labs/poindexter --json statusCheckRollup --jq '.statusCheckRollup[]? | {name, conclusion}'
+
+# If migrations-smoke + Mintlify Validation are SUCCESS (Mintlify Deployment FAILURE is acceptable, see prior PRs):
+gh pr merge $PR_NUM --repo Glad-Labs/poindexter --squash --delete-branch
+```
+
+---
+
+## Self-review notes
+
+This plan covers the spec's data model (Tasks 1, 8), the discovery + ranking flow (Tasks 3-7), the operator surface (Tasks 7, 15-16), the writer pivot (Tasks 9-14), the seed of Glad Labs (Task 17), and the migration deprecation (Task 19). All 7 spec tables are created in Task 1; all 4 writer modes are implemented (Tasks 10-13); the operator interactions cover show/rank/edit/resolve/reject; CLI + MCP both expose them.
+
+Acceptance criteria from the spec:
+
+- ✓ Glad Labs niche seeded with TWO_PASS + ≥3 goals summing to 100 (Task 17)
+- ✓ Discovery sweep produces 5-candidate batch (Tasks 6, 18)
+- ✓ `topics show-batch` CLI (Task 15)
+- ✓ rank → edit → resolve → content_task flow (Tasks 7, 14, 18)
+- ✓ topic_batch_id provenance on content_tasks (Task 8)
+- ✓ Carry-forward decay (Task 6)
+- ✓ One open batch per niche (UNIQUE partial index in Task 1)
+- ✓ Discovery floor (Task 6)
+- ✓ TWO_PASS writer (Task 13)
+- ✓ Existing pipeline stages unchanged downstream (Task 14)
+
+The 5 spec open questions are answered: (1) goal vector cache invalidation = process-restart only, fine for v1; (2) supporting_refs stores ref + snippet (Task 6); (3) LLM final-scorer prompt template inlined in Task 4; (4) approve-as-rank-1-unedited fallback works because resolve_batch reads operator_rank=1 — operators can omit rank-batch and use just resolve-batch only if there's already an operator_rank set (or the implementer can default operator_rank to rank_in_batch on insert — minor follow-up); (5) niche slug surfaced via CLI/MCP show-batch output.

--- a/docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md
+++ b/docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md
@@ -30,6 +30,26 @@ ls src/cofounder_agent/services/migrations/ | tail -3
 
 5. Confirm pgvector extension is loaded (`SELECT extname FROM pg_extension WHERE extname='vector'`). Migration 0103 added it; should already be present.
 
+6. Add `langgraph` to deps (Task 13 / TWO_PASS uses it; the simpler writer modes stay plain Python). Per spec §"OSS leverage decisions":
+
+```bash
+cd src/cofounder_agent
+poetry add "langgraph>=0.2,<1.0"
+poetry run python -c "from langgraph.graph import StateGraph; print('ok')"
+```
+
+7. Throughout implementation, wrap every new LLM call (ranker in Task 4, distiller in Task 5, writer modes in Tasks 10-13) with a Langfuse trace. Spec §"OSS leverage decisions" — Langfuse is already running, every call should be observable from day one. Pattern (use this everywhere we call `_ollama_chat_json`):
+
+```python
+from langfuse.decorators import observe
+
+@observe(name="topic_ranker_llm_score")
+async def llm_final_score(...):
+    ...
+```
+
+The exact decorator path depends on the project's Langfuse SDK version — check existing services for `@observe` usage and mirror.
+
 ---
 
 ## File structure
@@ -2035,37 +2055,171 @@ git commit -m "feat(writer): STORY_SPINE mode — structured outline pre-pass"
 
 ---
 
-## Task 13: Writer mode — TWO_PASS (Glad Labs default)
+## Task 13: Writer mode — TWO_PASS (Glad Labs default, LangGraph)
 
 **Files:**
 
 - Create: `src/cofounder_agent/services/writer_rag_modes/two_pass.py`
+- Test: `src/cofounder_agent/tests/unit/services/writer_rag_modes/test_two_pass.py`
 
-- [ ] **Step 1: Implement TWO_PASS**
+Per spec §"OSS leverage decisions" — TWO_PASS is the only writer mode that uses LangGraph (the others stay plain Python). The flow is a real state machine: `embed_and_fetch → draft → detect_needs → research_each → revise`, with a conditional edge from `revise` back to `detect_needs` if revision surfaces new `[EXTERNAL_NEEDED]` markers. Bounded by `_MAX_REVISION_LOOPS=3` so it can't spin forever.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/services/writer_rag_modes/test_two_pass.py
+import pytest
+from unittest.mock import AsyncMock
+from services.writer_rag_modes import two_pass
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_pool_with_no_snippets():
+    pool = AsyncMock()
+    conn_mock = AsyncMock()
+    conn_mock.fetch = AsyncMock(return_value=[])
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn_mock)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return pool
+
+
+async def test_no_external_needed_returns_pass1_draft(monkeypatch):
+    """First draft has no [EXTERNAL_NEEDED] markers → graph short-circuits, no revise."""
+    async def fake_pass1(topic, angle, snippets, extra_instructions=None):
+        return "A clean first draft with no markers."
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", fake_pass1)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.embedding_service.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert result["draft"] == "A clean first draft with no markers."
+    assert result["external_lookups"] == []
+    assert result["revision_loops"] == 0
+
+
+async def test_external_needed_triggers_research_and_revise(monkeypatch):
+    """One marker → research → revise → done in 1 loop."""
+    drafts = iter([
+        "First draft with [EXTERNAL_NEEDED: a fact] inside.",
+        "Revised draft with the actual fact inside.",
+    ])
+    async def fake_pass1(topic, angle, snippets, extra_instructions=None):
+        return next(drafts)
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", fake_pass1)
+    async def fake_revise(prompt, *, model):
+        return next(drafts)
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_revise)
+    async def fake_research(query, max_sources=2):
+        return f"External research result for: {query}"
+    monkeypatch.setattr("services.research_service.research_topic", fake_research)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.embedding_service.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert "Revised draft" in result["draft"]
+    assert len(result["external_lookups"]) == 1
+    assert result["revision_loops"] == 1
+
+
+async def test_loop_caps_at_max_revisions(monkeypatch):
+    """Pathological: every revision adds new markers. Loop must terminate at _MAX_REVISION_LOOPS=3."""
+    counter = {"n": 0}
+    async def always_needs_more(topic, angle, snippets, extra_instructions=None):
+        counter["n"] += 1
+        return f"Draft with [EXTERNAL_NEEDED: thing {counter['n']}] inside."
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", always_needs_more)
+    async def fake_revise(prompt, *, model):
+        counter["n"] += 1
+        return f"Revised with [EXTERNAL_NEEDED: another thing {counter['n']}]."
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_revise)
+    async def fake_research(query, max_sources=2):
+        return "fact"
+    monkeypatch.setattr("services.research_service.research_topic", fake_research)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.embedding_service.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert result["revision_loops"] == 3
+    assert result["loop_capped"] is True
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/writer_rag_modes/test_two_pass.py -v
+```
+
+Expected: ImportError on `two_pass` (or LangGraph import error if Step 6 of pre-flight wasn't run).
+
+- [ ] **Step 3: Implement TWO_PASS as a LangGraph state machine**
 
 ```python
 # services/writer_rag_modes/two_pass.py
-"""TWO_PASS — first draft from internal context only (no external research),
-then a fact-augmentation pass adds external corroboration where needed.
+"""TWO_PASS — internal-first draft, then conditional external fact-augmentation
+loop. Implemented as a LangGraph state machine because:
 
-Glad Labs default: maximum first-person reporting; external content only
-appears where the model identifies a claim that needs outside support."""
+- Multi-pass with conditional re-entry (revise can surface new
+  [EXTERNAL_NEEDED] markers that need another research pass)
+- Bounded loop (_MAX_REVISION_LOOPS=3 prevents runaway)
+- Future-friendly: when we add an auto-researcher agent or a draft-critic
+  loop, they slot in as new nodes/edges rather than refactoring orchestration
+
+Spec §"OSS leverage decisions" — TWO_PASS is the only writer mode using
+LangGraph; the simpler modes (TOPIC_ONLY, CITATION_BUDGET, STORY_SPINE)
+stay plain Python because they don't have branching.
+
+State flow:
+
+    embed_and_fetch → draft → detect_needs ┐
+                                            │ if needs found and loops < max:
+                                            ↓
+                                  research_each → revise ─┐
+                                                           │
+                                                           ↓
+                                                  detect_needs (loop)
+                                                           │
+                                                           ↓ if no needs OR loops capped
+                                                          END
+"""
 
 from __future__ import annotations
-from typing import Any
+
+import re
+from typing import Any, TypedDict
 from uuid import UUID
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.memory import MemorySaver
+
 from services.logger_config import get_logger
 
 logger = get_logger(__name__)
 
 
-async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
-    from services.embedding_service import embed_text
-    from services.topic_ranking import _ollama_chat_json
-    from services.ai_content_generator import generate_with_context
+_MAX_REVISION_LOOPS = 3
+_NEED_PATTERN = re.compile(r"\[EXTERNAL_NEEDED:\s*([^\]]+)\]")
 
-    qvec = await embed_text(f"{topic} — {angle}")
-    async with pool.acquire() as conn:
+
+class _State(TypedDict, total=False):
+    topic: str
+    angle: str
+    snippets: list[dict[str, Any]]
+    pool: Any
+    draft: str
+    needs: list[str]
+    research_results: list[dict[str, Any]]
+    external_lookups: list[dict[str, Any]]
+    revision_loops: int
+    loop_capped: bool
+
+
+# -- nodes --
+
+async def _embed_and_fetch_snippets(state: _State) -> _State:
+    from services.embedding_service import embed_text
+    qvec = await embed_text(f"{state['topic']} — {state['angle']}")
+    async with state["pool"].acquire() as conn:
         rows = await conn.fetch(
             """
             SELECT source_table, source_id, text_preview
@@ -2075,52 +2229,131 @@ async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) 
             """,
             qvec,
         )
-    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
-                for r in rows]
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]),
+                 "snippet": r["text_preview"]} for r in rows]
+    return {**state, "snippets": snippets, "revision_loops": 0,
+            "external_lookups": [], "loop_capped": False}
 
-    # Pass 1 — internal-only draft
-    pass1_instruction = (
-        "Write a first-draft blog post drawing ONLY from the provided internal snippets. "
-        "Do NOT make up external facts, statistics, or quotes you cannot ground in a snippet. "
-        "If you need an outside fact you don't have, mark it [EXTERNAL_NEEDED: <description>] "
-        "in the draft so a follow-up pass can fill it in."
+
+async def _draft_node(state: _State) -> _State:
+    from services.ai_content_generator import generate_with_context
+    instruction = (
+        "Write a first-draft blog post drawing ONLY from the provided internal "
+        "snippets. Do NOT make up external facts, statistics, or quotes you cannot "
+        "ground in a snippet. If you need an outside fact you don't have, mark it "
+        "[EXTERNAL_NEEDED: <description>] in the draft so a follow-up pass can fill it in."
     )
-    pass1_draft = await generate_with_context(
-        topic=topic, angle=angle, snippets=snippets,
-        extra_instructions=pass1_instruction,
+    draft = await generate_with_context(
+        topic=state["topic"], angle=state["angle"],
+        snippets=state["snippets"], extra_instructions=instruction,
     )
+    return {**state, "draft": draft}
 
-    # Find [EXTERNAL_NEEDED: ...] markers
-    import re
-    needs = re.findall(r"\[EXTERNAL_NEEDED:\s*([^\]]+)\]", pass1_draft)
-    if not needs:
-        return {"draft": pass1_draft, "snippets_used": snippets,
-                "external_lookups": [], "mode": "TWO_PASS"}
 
-    # Pass 2 — external fact-augmentation
+def _detect_needs(state: _State) -> _State:
+    needs = _NEED_PATTERN.findall(state["draft"])
+    return {**state, "needs": [n.strip() for n in needs]}
+
+
+async def _research_each(state: _State) -> _State:
     from services.research_service import research_topic
-    augmentations = []
-    for need in needs:
-        aug = await research_topic(query=need.strip(), max_sources=2)
-        augmentations.append({"need": need.strip(), "research": aug})
+    results = []
+    for need in state["needs"]:
+        aug = await research_topic(query=need, max_sources=2)
+        results.append({"need": need, "research": aug})
+    cumulative = list(state.get("external_lookups") or []) + results
+    return {**state, "research_results": results, "external_lookups": cumulative}
 
-    aug_block = "\n\n".join(f"[EXTERNAL_NEEDED: {a['need']}] → {a['research']}" for a in augmentations)
+
+async def _revise_node(state: _State) -> _State:
+    from services.topic_ranking import _ollama_chat_json
+    aug_block = "\n\n".join(
+        f"[EXTERNAL_NEEDED: {r['need']}] → {r['research']}"
+        for r in state["research_results"]
+    )
     revise_prompt = f"""Revise the following draft. For each [EXTERNAL_NEEDED: ...] marker,
-substitute the corresponding external fact provided below. Keep the rest unchanged.
+substitute the corresponding external fact provided below. Keep everything else unchanged.
+If revision exposes a new claim that needs outside support, mark it [EXTERNAL_NEEDED: ...]
+again so the next pass can fill it.
 
 Original draft:
-{pass1_draft}
+{state['draft']}
 
 External facts:
 {aug_block}
 """
-    final_draft = await _ollama_chat_json(revise_prompt, model="glm-4.7-5090:latest")
+    new_draft = await _ollama_chat_json(revise_prompt, model="glm-4.7-5090:latest")
+    return {**state, "draft": new_draft, "revision_loops": state.get("revision_loops", 0) + 1}
+
+
+def _mark_capped(state: _State) -> _State:
+    return {**state, "loop_capped": True}
+
+
+# -- conditional edges --
+
+def _needs_or_done(state: _State) -> str:
+    """After detect_needs: route to research_each if needs found AND we haven't
+    hit the loop cap, else END (or _done_capped if we're capping)."""
+    if not state.get("needs"):
+        return END
+    if state.get("revision_loops", 0) >= _MAX_REVISION_LOOPS:
+        return "_done_capped"
+    return "research_each"
+
+
+def _build_graph():
+    g = StateGraph(_State)
+    g.add_node("embed_and_fetch", _embed_and_fetch_snippets)
+    g.add_node("draft", _draft_node)
+    g.add_node("detect_needs", _detect_needs)
+    g.add_node("research_each", _research_each)
+    g.add_node("revise", _revise_node)
+    g.add_node("_done_capped", _mark_capped)
+
+    g.set_entry_point("embed_and_fetch")
+    g.add_edge("embed_and_fetch", "draft")
+    g.add_edge("draft", "detect_needs")
+    g.add_conditional_edges("detect_needs", _needs_or_done, {
+        "research_each": "research_each",
+        "_done_capped": "_done_capped",
+        END: END,
+    })
+    g.add_edge("research_each", "revise")
+    g.add_edge("revise", "detect_needs")
+    g.add_edge("_done_capped", END)
+
+    # MemorySaver checkpointer means the graph CAN be paused mid-run and
+    # resumed — useful when an operator interrupts mid-revision in v2.
+    # v1 uses in-memory; v2 swaps to a postgres checkpointer for
+    # cross-process durability.
+    return g.compile(checkpointer=MemorySaver())
+
+
+_GRAPH = _build_graph()
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    initial: _State = {"topic": topic, "angle": angle, "pool": pool}
+    config = {"configurable": {"thread_id": f"two_pass-{niche_id}-{topic[:32]}"}}
+    final = await _GRAPH.ainvoke(initial, config=config)
     return {
-        "draft": final_draft, "pass1_draft": pass1_draft,
-        "snippets_used": snippets, "external_lookups": augmentations,
+        "draft": final["draft"],
+        "snippets_used": final.get("snippets", []),
+        "external_lookups": final.get("external_lookups", []),
+        "revision_loops": final.get("revision_loops", 0),
+        "loop_capped": final.get("loop_capped", False),
         "mode": "TWO_PASS",
     }
 ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/cofounder_agent && poetry run pytest tests/unit/services/writer_rag_modes/test_two_pass.py -v
+```
+
+Expected: 3 PASSED.
 
 - [ ] **Step 2: Commit**
 

--- a/docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
@@ -1,0 +1,293 @@
+# RAG Pivot + Niche-Aware Topic Discovery — Design
+
+**Status:** Approved (brainstorming complete, awaiting implementation plan)
+**Date:** 2026-04-30
+**Author:** Brainstorming session — Matt + Claude (Opus 4.7)
+**Implementation skill to invoke next:** `superpowers:writing-plans`
+
+## Why
+
+The content pipeline currently summarizes external content (Hacker News, dev.to, web search). It produces ~20 4000-word drafts per day; most get rejected by Matt at the title/topic level — meaning we burn the full pipeline cost (research → draft → QA → image → SEO) on posts that lose at the very first human touch.
+
+The economic argument:
+
+> One LLM call to rank 5 topics ≪ one full content pipeline run. Gating at topic selection avoids burning compute on posts that get rejected at the title/topic level anyway. Improving upstream selection pays for itself many times over in downstream compute saved.
+
+The strategic argument:
+
+> Glad Labs is a primary source about building an AI-run business. We have 8,500 claude_session embeddings, 4,095 brain_knowledge entries, 3,460 audit events, decision logs, git history. We can produce content nobody else can — first-person reporting on what an autonomous AI business actually does — instead of yet another summary of someone else's content.
+
+The flexibility argument:
+
+> Glad Labs is the FIRST niche this system serves. The system MUST be configurable as a niche, not pinned to a niche. Future operators (a homestead permaculture journal, an indie game devlog, a real-estate investing newsletter) configure their own niche with their own goals, sources, and writer style.
+
+## What changes
+
+| Surface                 | Before                                               | After                                                                                                                                         |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Topic discovery cadence | Pure cron, generates topics per niche-blind defaults | Per-niche, reactive (fires when prior batch resolves), with a per-niche minute floor                                                          |
+| Topic batch shape       | Single proposed topic at a time, approve/reject      | Batch of N (default 5) candidates, operator ranks 1-5 + optionally edits the #1                                                               |
+| Candidate sources       | External feeds only (HN, dev.to, web_search)         | External feeds + internal RAG sources (claude_sessions, brain_knowledge, audit_events, git_commits, decision_log, memory_files, post_history) |
+| Ranking signal          | Heuristic + multi-model QA scores after generation   | Hybrid embedding-cosine + LLM scorer against per-niche weighted goals, before generation                                                      |
+| Writer stage            | Researches external sources, summarizes              | Per-niche writer mode; for Glad Labs (TWO_PASS): internal-context-only first draft, external-fact-augmentation second pass                    |
+| Operator gate           | `topic_decision` approve/reject on a single proposal | Same gate, light-reuse: gate pauses pipeline; new MCP tools mutate the batch (rank, edit, resolve)                                            |
+
+## Data model
+
+### `niches`
+
+The first-class configuration surface. One row per audience the operator publishes for.
+
+```sql
+CREATE TABLE niches (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug            TEXT UNIQUE NOT NULL,           -- e.g. 'glad-labs', 'permaculture-journal'
+    name            TEXT NOT NULL,
+    active          BOOLEAN NOT NULL DEFAULT true,
+    target_audience_tags TEXT[] NOT NULL DEFAULT '{}',
+        -- e.g. {'indie-devs','ai-curious','prospects'}; multi-audience per niche
+    writer_prompt_override TEXT,                    -- NULL = use default writer prompt
+    writer_rag_mode TEXT NOT NULL DEFAULT 'TOPIC_ONLY',
+        -- ENUM: TOPIC_ONLY | CITATION_BUDGET | STORY_SPINE | TWO_PASS
+        -- Glad Labs default: TWO_PASS
+    batch_size      INT NOT NULL DEFAULT 5,
+    discovery_cadence_minute_floor INT NOT NULL DEFAULT 60,
+        -- the per-niche minute floor for the reactive trigger
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### `niche_goals`
+
+Weighted goals the ranker scores candidates against.
+
+```sql
+CREATE TABLE niche_goals (
+    niche_id   UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+    goal_type  TEXT NOT NULL,
+        -- ENUM: TRAFFIC | EDUCATION | BRAND | AUTHORITY | REVENUE
+        --     | COMMUNITY | NICHE_DEPTH
+    weight_pct INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+    PRIMARY KEY (niche_id, goal_type)
+);
+-- Per-niche constraint enforced at write time: SUM(weight_pct) FOR niche_id ≈ 100
+```
+
+### `niche_sources`
+
+Per-niche toggle + weight for each candidate source plugin. Plugins themselves stay in `services/topic_sources/` (unchanged from today).
+
+```sql
+CREATE TABLE niche_sources (
+    niche_id    UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+    source_name TEXT NOT NULL,
+        -- e.g. 'hackernews', 'devto', 'web_search', 'codebase', 'knowledge', 'internal_rag'
+    enabled     BOOLEAN NOT NULL DEFAULT true,
+    weight_pct  INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+        -- influences how many candidates this source contributes to the pre-rank pool
+    PRIMARY KEY (niche_id, source_name)
+);
+```
+
+### `topic_batches`
+
+The unit of operator interaction.
+
+```sql
+CREATE TABLE topic_batches (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    niche_id     UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+    status       TEXT NOT NULL,
+        -- ENUM: open | resolved | expired
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at   TIMESTAMPTZ NOT NULL,
+        -- e.g. created_at + 7 days; auto-expire so dead batches don't block forever
+    resolved_at  TIMESTAMPTZ,
+    picked_candidate_id UUID,
+        -- references either topic_candidates(id) or internal_topic_candidates(id);
+        -- the picked_candidate_kind column below disambiguates
+    picked_candidate_kind TEXT
+        -- ENUM: external | internal | NULL (until resolved)
+);
+-- One open batch per niche at a time:
+CREATE UNIQUE INDEX uq_one_open_batch_per_niche
+    ON topic_batches (niche_id) WHERE status = 'open';
+```
+
+### `topic_candidates` (external)
+
+Candidates from external source plugins (HN, dev.to, web_search, etc).
+
+```sql
+CREATE TABLE topic_candidates (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+    niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,  -- denorm
+    source_name     TEXT NOT NULL,
+    source_ref      TEXT NOT NULL,         -- URL or external id from the source
+    title           TEXT NOT NULL,
+    summary         TEXT,
+    score           NUMERIC NOT NULL,      -- 0-100, from the LLM final scorer
+    score_breakdown JSONB NOT NULL,        -- {goal_type: contribution_pct, ...}
+    rank_in_batch   INT NOT NULL,          -- system's pre-operator rank, 1-N
+    operator_rank   INT,                   -- operator's rank, NULL until they act
+    operator_edited_topic TEXT,            -- operator's optional title rewrite
+    operator_edited_angle TEXT,            -- operator's optional summary rewrite
+    decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+        -- multiplied by 0.7 each time the candidate carries forward unpicked
+    carried_from_batch_id UUID REFERENCES topic_batches(id),
+        -- NULL on first appearance
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (batch_id, source_name, source_ref)
+);
+```
+
+### `internal_topic_candidates` (RAG-derived)
+
+Different shape from external, separate table.
+
+```sql
+CREATE TABLE internal_topic_candidates (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+    niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+    source_kind     TEXT NOT NULL,
+        -- ENUM: claude_session | brain_knowledge | audit_event
+        --     | git_commit | decision_log | memory_file | post_history
+    primary_ref     TEXT NOT NULL,
+        -- the row id / commit sha / memory file path that anchors this candidate
+    supporting_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+        -- list of {source_kind, ref, snippet} the RAG retriever pulled in alongside
+    distilled_topic TEXT NOT NULL,
+        -- what the LLM extracted as the proposed post topic
+    distilled_angle TEXT NOT NULL,
+        -- the "why this matters / what we learned" framing
+    score           NUMERIC NOT NULL,
+    score_breakdown JSONB NOT NULL,
+    rank_in_batch   INT NOT NULL,
+    operator_rank   INT,
+    operator_edited_topic TEXT,
+    operator_edited_angle TEXT,
+    decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+    carried_from_batch_id UUID REFERENCES topic_batches(id),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### `discovery_runs`
+
+Observability: when did the discovery worker fire, what did it produce.
+
+```sql
+CREATE TABLE discovery_runs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ,
+    candidates_generated      INT,
+    candidates_carried_forward INT,
+    batch_id        UUID REFERENCES topic_batches(id),
+    error           TEXT
+);
+```
+
+## Flow
+
+### 1. Discovery sweep (per niche, single-niche per sweep)
+
+Triggered by either:
+
+- Reactive: a previous `topic_batch.status` transitions to `resolved` → the next sweep is scheduled, subject to the per-niche minute floor.
+- Operator-on-demand: `poindexter topics discover --niche <slug>` (also subject to floor; pass `--force` to bypass).
+
+Steps:
+
+1. Pick a niche where the floor has elapsed AND no open batch exists.
+2. For each enabled `niche_source`, ask the source plugin to produce candidates proportional to its `weight_pct` (target pool size: ~20 total).
+3. Carry-forward: load any candidates from the niche's last batch that weren't picked, multiply their `decay_factor` by 0.7, include in the pool.
+4. Embedding pre-rank: compute candidate embeddings; for each enabled `niche_goal`, cosine-similarity against a precomputed "goal vector" (an embedding of a fixed prose description per goal_type, see "Goal vectors" below). Weighted-sum across goals × `weight_pct` × `decay_factor` → preliminary score. Take top 10.
+5. LLM final scoring: one `glm-4.7-5090` call (per the project's local-LLM policy) prompts the model with the niche's goals + weights and the top-10 list, gets back JSON { candidate_id: { score, score_breakdown } }.
+6. Take top `batch_size` (default 5). Insert into `topic_candidates` / `internal_topic_candidates` with `batch_id`, write a new `topic_batches` row with `status='open'`.
+7. Open the `topic_decision` gate (light-reuse — gate just flags "operator action needed").
+8. Record the run in `discovery_runs`.
+
+### 2. Operator interaction
+
+- `poindexter topics show-batch [--niche <slug>]` — print the current open batch with system rank, score, score_breakdown, source info.
+- `poindexter topics rank-batch <batch_id> --order <id1>,<id2>,<id3>,<id4>,<id5>` — operator's 1-5 ranking.
+- `poindexter topics edit-winner <batch_id> [--topic <text>] [--angle <text>]` — optional rewrite of the #1 candidate's title/angle (writes to `operator_edited_topic` / `operator_edited_angle`).
+- `poindexter topics resolve-batch <batch_id>` — finalizes: marks the batch resolved, sets `picked_candidate_id` to operator_rank=1, advances that candidate to the research stage.
+- `poindexter topics reject-batch <batch_id> [--reason <text>]` — discards the batch, schedules a fresh sweep.
+
+Same surface gets exposed as MCP tools (so the voice bot can drive it) and Telegram-friendly summaries (so phone-only operation works). All three are thin wrappers over the same service-layer functions.
+
+### 3. Pipeline handoff
+
+When `resolve-batch` runs:
+
+1. The picked candidate's `operator_edited_topic` (if set) overrides `title` / `distilled_topic`.
+2. A new `content_task` is created with `topic`, `angle`, the niche's `slug`, the niche's `writer_rag_mode`, and a `topic_batch_id` provenance pointer.
+3. The existing pipeline (research → draft → QA → SEO → finalize) runs as today, but the writer stage reads `writer_rag_mode` and adapts:
+   - **TOPIC_ONLY** — writer gets topic + angle, runs one embedding query, dumps top-N internal snippets as background context.
+   - **CITATION_BUDGET** — writer required to cite ≥ N internal sources; content_validator extends existing citation rules to enforce.
+   - **STORY_SPINE** — preprocessing LLM call reads top 10-15 internal snippets and produces a structured outline; writer expands the outline.
+   - **TWO_PASS** — first draft from internal context only (no external research call). Second pass: a fact-augmentation step pulls external for any claims that need outside support; writer revises. Glad Labs default.
+
+## Goal vectors
+
+Each `goal_type` has a fixed prose description used to compute its embedding once, then cached. Stored in code (not DB) since they're configuration, not user data:
+
+```python
+GOAL_DESCRIPTIONS = {
+    "TRAFFIC":     "Topic likely to attract organic search traffic; trending keyword, broad appeal, evergreen demand.",
+    "EDUCATION":   "Topic that teaches the reader something concrete and useful they didn't know before.",
+    "BRAND":       "Topic that reinforces the operator's positioning and unique perspective.",
+    "AUTHORITY":   "Topic that demonstrates the operator's depth and expertise on something specific.",
+    "REVENUE":     "Topic that drives a commercial outcome: signups, sales, conversions, paid feature awareness.",
+    "COMMUNITY":   "Topic that resonates with the operator's existing audience; sparks discussion, shares, replies.",
+    "NICHE_DEPTH": "Topic that goes deep on the operator's niche specialty rather than broad-audience content.",
+}
+```
+
+These are what the embedding pre-ranker scores candidates against. Cosine similarity to each goal's vector × the niche's weight for that goal × the candidate's decay_factor.
+
+## Migration plan
+
+1. **Keep** `services/topic_discovery.py` (source-plugin runner — fine as-is).
+2. **Keep** `services/topic_dedup.py` and `services/topic_dedup_semantic.py` (dedup layer — fine as-is).
+3. **Replace** `services/topic_proposal_service.py` entirely with a new `services/topic_batch_service.py` that orchestrates discovery → pre-rank → LLM score → batch creation → operator interaction → handoff. The old service's callers get repointed.
+4. **Light-reuse** the existing `topic_decision` approval gate. Gate stays as the pause/release mechanism; the batch row holds the data; new MCP tools mutate the batch.
+5. **Schema migration** seeds Glad Labs as the first niche, with goals + sources matching today's behavior so nothing regresses on day-zero.
+
+Existing topic_proposals data: there shouldn't be much in flight (Matt's been rejecting heavily). Migration drops the old table after a short observation window.
+
+## Out of scope
+
+- **Pipeline gateway caps** — the "max 1 task awaiting draft approval / max 1 task awaiting publish approval" backpressure feature. Genuinely separate concern (different code paths, different gates table). Punted to its own spec.
+- **Multi-niche concurrency** — sweeps run one niche at a time. Future-friendly schema (every table has `niche_id`) but the worker is serial for v1.
+- **Goal-driven analytics dashboard** — once `score_breakdown` data accumulates, a Grafana panel showing "which goal weights drive your accept rate" would be useful, but that's a follow-up.
+- **Auto-tuning niche weights** — the system could learn from operator rankings to adjust `niche_goals.weight_pct`, but v1 is operator-set only.
+
+## Acceptance criteria
+
+- [ ] Glad Labs niche exists in `niches` with `writer_rag_mode='TWO_PASS'` and at least 3 goals weighted to sum to 100.
+- [ ] A discovery sweep produces a batch of 5 candidates with mixed external + internal sources.
+- [ ] `poindexter topics show-batch` renders the batch with score breakdown per candidate.
+- [ ] `poindexter topics rank-batch` + `edit-winner` + `resolve-batch` flow advances a content_task into the existing pipeline.
+- [ ] The new `topic_batch_id` provenance pointer is queryable from the `posts` row backwards to the batch the topic came from.
+- [ ] Carrying forward an unpicked candidate cuts its score by ≥30% on the next batch (decay_factor ≤ 0.7).
+- [ ] No more than one open batch per niche exists at any time (UNIQUE partial index enforces).
+- [ ] The reactive trigger doesn't fire more often than the niche's `discovery_cadence_minute_floor`.
+- [ ] Glad Labs writer in TWO_PASS mode produces a draft whose first pass cites ≥3 internal sources before the external augmentation pass.
+- [ ] All existing pipeline stages (research → QA → SEO → finalize) still run unchanged downstream of the new topic flow.
+
+## Open questions for the implementation plan
+
+These don't block the spec, but the plan should answer:
+
+1. Goal vector cache invalidation strategy when the GOAL_DESCRIPTIONS dict ships an updated string.
+2. Whether `internal_topic_candidates.supporting_refs` JSONB should include the actual snippet text or only refs (snippets cost storage; refs cost a re-fetch at writer-stage).
+3. The exact prompt template for the LLM final-scorer pass — there are several reasonable shapes.
+4. Whether `topic_decision` gate's existing approve/reject CLI should remain available as a fallback (operator approve = "advance #1 unedited", operator reject = "discard batch") — likely yes for backwards compat.
+5. How the niche slug surfaces in the UI when batches from multiple niches eventually overlap (post-v1 concern).

--- a/docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
@@ -282,6 +282,26 @@ Existing topic_proposals data: there shouldn't be much in flight (Matt's been re
 - [ ] Glad Labs writer in TWO_PASS mode produces a draft whose first pass cites ≥3 internal sources before the external augmentation pass.
 - [ ] All existing pipeline stages (research → QA → SEO → finalize) still run unchanged downstream of the new topic flow.
 
+## OSS leverage decisions
+
+Audit added 2026-04-30 after Matt asked which existing stack pieces this work should lean on (the project already runs Langfuse, Prefect 3, pgvector, plus has Ragas in-tree, and Issues #199/#202/#209 track candidate adoptions of LiteLLM / Langfuse experiments / LangGraph).
+
+**Adopting in this spec:**
+
+- **LangGraph** — for the TWO_PASS writer mode only. Two-pass flow is a real state machine (draft → detect [EXTERNAL_NEEDED] markers → research each → revise, with conditional re-entry if revision surfaces new gaps), and operator-interrupt checkpointing gives us "batch sits awaiting operator for days, resumes cleanly" for free. Future agent-y additions (auto-researcher, draft critic loop) become natural extensions of the same graph. Not used for the simpler writer modes (TOPIC_ONLY, CITATION_BUDGET, STORY_SPINE — single-pass, no branching) and not used for the discovery/ranking/batch flow (serial pipeline + DB CRUD, no LLM-driven decisions).
+
+**Mentioned in this spec, deferred to follow-up tasks:**
+
+- **Langfuse** — already deployed (5 containers running). Every LLM call we add (ranker, internal-RAG distiller, all 4 writer modes) should be wrapped in a Langfuse trace from day one. Free observability + the dataset accumulation lets us migrate to Langfuse Prompt Management (tune goal_descriptions + writer prompts without code changes) and Langfuse Experiments (A/B test writer modes against each other) in a follow-up. Tracked by issue #202.
+- **Ragas** — `services/ragas_eval.py` exists in-tree but isn't wired to the new code yet. The TWO_PASS writer is its bullseye use case: faithfulness (does the draft only assert things grounded in the snippets?), context precision (did we retrieve the right snippets?), context recall (did we miss obvious ones?). Add a Ragas evaluation step on every writer output as a follow-up; gate publishes on minimum scores once we calibrate.
+- **DeepEval GEval** — could replace the hand-rolled "LLM scores candidates against weighted goals" prompt in Task 4 with a battle-tested rubric framework. Worth migrating to in a follow-up once the v1 prompt's behavior is understood.
+- **LiteLLM** — Issue #199 wants the LLM-call layer migrated. New code in this PR uses direct httpx Ollama calls (consistent with the rest of the codebase) so we don't expand LiteLLM's scope mid-migration; when #199 lands, our new calls migrate alongside.
+
+**Skipped — would be over-engineering for v1:**
+
+- LangChain retrievers (we already have pgvector + embedding_service, adding LangChain just to wrap them is dependency tax)
+- Custom orchestration framework for discovery/ranking — Prefect 3 already runs the content pipeline; the new sweep can join the same flow registry without new tooling
+
 ## Open questions for the implementation plan
 
 These don't block the spec, but the plan should answer:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -925,5 +925,98 @@ async def get_brain_knowledge(entity: str = "", attribute: str = "", limit: int 
         return _format_tool_error("Brain knowledge query", e)
 
 
+# ============================================================================
+# NICHE TOPIC-DISCOVERY TOOLS
+# ============================================================================
+# Mirror the ``poindexter topics ...`` CLI commands so an MCP client can drive
+# the discover -> rank -> batch -> gate flow exposed by
+# ``services.topic_batch_service.TopicBatchService``.
+
+
+@mcp.tool()
+async def topics_show_batch(niche: str) -> str:
+    """Show the current open batch for a niche, sorted by effective_score."""
+    try:
+        pool = await _get_pool()
+        from services.niche_service import NicheService
+        from services.topic_batch_service import TopicBatchService
+        n = await NicheService(pool).get_by_slug(niche)
+        if not n:
+            return f"unknown niche: {niche}"
+        async with pool.acquire() as conn:
+            bid = await conn.fetchval(
+                "SELECT id FROM topic_batches WHERE niche_id = $1 AND status = 'open'",
+                n.id,
+            )
+        if bid is None:
+            return f"No open batch for niche {niche}."
+        view = await TopicBatchService(pool).show_batch(batch_id=bid)
+        lines = [f"Batch {view.id} (status={view.status}, niche={niche})"]
+        for c in view.candidates:
+            marker = f"#{c.operator_rank}" if c.operator_rank else f"sys#{c.rank_in_batch}"
+            lines.append(
+                f"  {marker:6s} [{c.kind:8s}] eff={c.effective_score:5.1f} | {c.id} | {c.title}"
+            )
+        return "\n".join(lines)
+    except Exception as e:
+        return _format_tool_error("topics_show_batch", e)
+
+
+@mcp.tool()
+async def topics_rank_batch(batch_id: str, ordered_candidate_ids: list[str]) -> str:
+    """Set operator ranking for a batch's candidates. Pass IDs in best-first order."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).rank_batch(
+            batch_id=batch_id, ordered_candidate_ids=ordered_candidate_ids,
+        )
+        return f"Ranked {len(ordered_candidate_ids)} candidates in batch {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_rank_batch", e)
+
+
+@mcp.tool()
+async def topics_edit_winner(batch_id: str, topic: str = "", angle: str = "") -> str:
+    """Edit the title/angle of the rank-1 candidate before resolution."""
+    if not topic and not angle:
+        return "topics_edit_winner failed: provide topic and/or angle"
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).edit_winner(
+            batch_id=batch_id,
+            topic=topic or None,
+            angle=angle or None,
+        )
+        return "Edited winner."
+    except Exception as e:
+        return _format_tool_error("topics_edit_winner", e)
+
+
+@mcp.tool()
+async def topics_resolve_batch(batch_id: str) -> str:
+    """Resolve a batch — advance the rank-1 candidate into the content pipeline."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).resolve_batch(batch_id=batch_id)
+        return f"Resolved {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_resolve_batch", e)
+
+
+@mcp.tool()
+async def topics_reject_batch(batch_id: str, reason: str = "") -> str:
+    """Reject a batch — discard candidates, allow a fresh sweep."""
+    try:
+        pool = await _get_pool()
+        from services.topic_batch_service import TopicBatchService
+        await TopicBatchService(pool).reject_batch(batch_id=batch_id, reason=reason)
+        return f"Rejected {batch_id}"
+    except Exception as e:
+        return _format_tool_error("topics_reject_batch", e)
+
+
 if __name__ == "__main__":
     mcp.run(transport="stdio")

--- a/src/cofounder_agent/poetry.lock
+++ b/src/cofounder_agent/poetry.lock
@@ -1953,6 +1953,33 @@ files = [
 ]
 
 [[package]]
+name = "jsonpatch"
+version = "1.33"
+description = "Apply JSON-Patches (RFC 6902)"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+groups = ["main"]
+files = [
+    {file = "jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade"},
+    {file = "jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c"},
+]
+
+[package.dependencies]
+jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+description = "Identify specific nodes in a JSON document (RFC 6901) "
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca"},
+    {file = "jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900"},
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -1988,6 +2015,146 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "langchain-core"
+version = "1.3.2"
+description = "Building applications with LLMs through composability"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main"]
+files = [
+    {file = "langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274"},
+    {file = "langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7"},
+]
+
+[package.dependencies]
+jsonpatch = ">=1.33.0,<2.0.0"
+langchain-protocol = ">=0.0.10"
+langsmith = ">=0.3.45,<1.0.0"
+packaging = ">=23.2.0"
+pydantic = ">=2.7.4,<3.0.0"
+pyyaml = ">=5.3.0,<7.0.0"
+tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
+typing-extensions = ">=4.7.0,<5.0.0"
+uuid-utils = ">=0.12.0,<1.0"
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.14"
+description = "Python bindings for the LangChain agent streaming protocol"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main"]
+files = [
+    {file = "langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047"},
+    {file = "langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.7.0,<5.0.0"
+
+[[package]]
+name = "langgraph"
+version = "0.6.11"
+description = "Building stateful, multi-actor applications with LLMs"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langgraph-0.6.11-py3-none-any.whl", hash = "sha256:49268de69d85b7db3da9e2ca582a474516421c1c44be5cff390416cfa6967faa"},
+    {file = "langgraph-0.6.11.tar.gz", hash = "sha256:cd5373d0a59701ab39c9f8af33a33c5704553de815318387fa7f240511e0efd7"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.1"
+langgraph-checkpoint = ">=2.1.0,<4.0.0"
+langgraph-prebuilt = ">=0.6.0,<0.7.0"
+langgraph-sdk = ">=0.2.2,<0.3.0"
+pydantic = ">=2.7.4"
+xxhash = ">=3.5.0"
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "3.0.1"
+description = "Library with base interfaces for LangGraph checkpoint savers."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_checkpoint-3.0.1-py3-none-any.whl", hash = "sha256:9b04a8d0edc0474ce4eaf30c5d731cee38f11ddff50a6177eead95b5c4e4220b"},
+    {file = "langgraph_checkpoint-3.0.1.tar.gz", hash = "sha256:59222f875f85186a22c494aedc65c4e985a3df27e696e5016ba0b98a5ed2cee0"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.2.38"
+ormsgpack = ">=1.12.0"
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "0.6.5"
+description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langgraph_prebuilt-0.6.5-py3-none-any.whl", hash = "sha256:b6ceb5db31c16a30a3ee3c0b923667f02e7c9e27852621abf9d5bd5603534141"},
+    {file = "langgraph_prebuilt-0.6.5.tar.gz", hash = "sha256:9c63e9e867e62b345805fd1e8ea5c2df5cc112e939d714f277af84f2afe5950d"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.3.67"
+langgraph-checkpoint = ">=2.1.0,<4.0.0"
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.2.15"
+description = "SDK for interacting with LangGraph API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_sdk-0.2.15-py3-none-any.whl", hash = "sha256:746566a5d89aa47160eccc17d71682a78771c754126f6c235a68353d61ed7462"},
+    {file = "langgraph_sdk-0.2.15.tar.gz", hash = "sha256:8faaafe2c1193b89f782dd66c591060cd67862aa6aaf283749b7846f331d5334"},
+]
+
+[package.dependencies]
+httpx = ">=0.25.2"
+orjson = ">=3.10.1"
+
+[[package]]
+name = "langsmith"
+version = "0.7.38"
+description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langsmith-0.7.38-py3-none-any.whl", hash = "sha256:9c400ad508c0e4edc37bd55987047c6b8aac36ddd55f6096e3806f4d6a100618"},
+    {file = "langsmith-0.7.38.tar.gz", hash = "sha256:0db529b768d66c45f22fe959a0af7151342704fefafdecf3c60b14097c14fdb1"},
+]
+
+[package.dependencies]
+httpx = ">=0.23.0,<1"
+orjson = {version = ">=3.9.14", markers = "platform_python_implementation != \"PyPy\""}
+packaging = ">=23.2"
+pydantic = ">=2,<3"
+requests = ">=2.0.0"
+requests-toolbelt = ">=1.0.0"
+uuid-utils = ">=0.12.0,<1.0"
+xxhash = ">=3.0.0"
+zstandard = ">=0.23.0"
+
+[package.extras]
+claude-agent-sdk = ["claude-agent-sdk (>=0.1.0) ; python_version >= \"3.10\""]
+google-adk = ["google-adk (>=1.0.0)", "wrapt (>=1.16.0)"]
+langsmith-pyo3 = ["langsmith-pyo3 (>=0.1.0rc2)"]
+openai-agents = ["openai-agents (>=0.0.3)"]
+otel = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)"]
+pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4)", "vcrpy (>=7.0.0)"]
+sandbox = ["websockets (>=15.0)"]
+strands-agents = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)", "strands-agents (>=0.1.0)", "strands-agents-tools (>=0.2.0)"]
+vcr = ["vcrpy (>=7.0.0)"]
 
 [[package]]
 name = "lazy-object-proxy"
@@ -3121,6 +3288,149 @@ files = [
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615"},
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f"},
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e"},
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.8"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "orjson-3.11.8-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e6693ff90018600c72fd18d3d22fa438be26076cd3c823da5f63f7bab28c11cb"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93de06bc920854552493c81f1f729fab7213b7db4b8195355db5fda02c7d1363"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fe0b8c83e0f36247fc9431ce5425a5d95f9b3a689133d494831bdbd6f0bceb13"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d823831105c01f6c8029faf297633dbeb30271892bd430e9c24ceae3734744"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60c0423f15abb6cf78f56dff00168a1b582f7a1c23f114036e2bfc697814d5f"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01928d0476b216ad2201823b0a74000440360cef4fed1912d297b8d84718f277"},
+    {file = "orjson-3.11.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a4a639049c44d36a6d1ae0f4a94b271605c745aee5647fa8ffaabcdc01b69a6"},
+    {file = "orjson-3.11.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3222adff1e1ff0dce93c16146b93063a7793de6c43d52309ae321234cdaf0f4d"},
+    {file = "orjson-3.11.8-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3223665349bbfb68da234acd9846955b1a0808cbe5520ff634bf253a4407009b"},
+    {file = "orjson-3.11.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:61c9d357a59465736022d5d9ba06687afb7611dfb581a9d2129b77a6fcf78e59"},
+    {file = "orjson-3.11.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:58fb9b17b4472c7b1dcf1a54583629e62e23779b2331052f09a9249edf81675b"},
+    {file = "orjson-3.11.8-cp310-cp310-win32.whl", hash = "sha256:b43dc2a391981d36c42fa57747a49dae793ef1d2e43898b197925b5534abd10a"},
+    {file = "orjson-3.11.8-cp310-cp310-win_amd64.whl", hash = "sha256:c98121237fea2f679480765abd566f7713185897f35c9e6c2add7e3a9900eb61"},
+    {file = "orjson-3.11.8-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:003646067cc48b7fcab2ae0c562491c9b5d2cbd43f1e5f16d98fd118c5522d34"},
+    {file = "orjson-3.11.8-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:ed193ce51d77a3830cad399a529cd4ef029968761f43ddc549e1bc62b40d88f8"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f30491bc4f862aa15744b9738517454f1e46e56c972a2be87d70d727d5b2a8f8"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eda5b8b6be91d3f26efb7dc6e5e68ee805bc5617f65a328587b35255f138bf4"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee8db7bfb6fe03581bbab54d7c4124a6dd6a7f4273a38f7267197890f094675f"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d8b5231de76c528a46b57010bbd83fb51e056aa0220a372fd5065e978406f1c"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58a4a208a6fbfdb7a7327b8f201c6014f189f721fd55d047cafc4157af1bc62a"},
+    {file = "orjson-3.11.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f8952d6d2505c003e8f0224ff7858d341fa4e33fef82b91c4ff0ef070f2393c"},
+    {file = "orjson-3.11.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0022bb50f90da04b009ce32c512dc1885910daa7cb10b7b0cba4505b16db82a8"},
+    {file = "orjson-3.11.8-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ff51f9d657d1afb6f410cb435792ce4e1fe427aab23d2fcd727a2876e21d4cb6"},
+    {file = "orjson-3.11.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6dbe9a97bdb4d8d9d5367b52a7c32549bba70b2739c58ef74a6964a6d05ae054"},
+    {file = "orjson-3.11.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5c370674ebabe16c6ccac33ff80c62bf8a6e59439f5e9d40c1f5ab8fd2215b7"},
+    {file = "orjson-3.11.8-cp311-cp311-win32.whl", hash = "sha256:0e32f7154299f42ae66f13488963269e5eccb8d588a65bc839ed986919fc9fac"},
+    {file = "orjson-3.11.8-cp311-cp311-win_amd64.whl", hash = "sha256:25e0c672a2e32348d2eb33057b41e754091f2835f87222e4675b796b92264f06"},
+    {file = "orjson-3.11.8-cp311-cp311-win_arm64.whl", hash = "sha256:9185589c1f2a944c17e26c9925dcdbc2df061cc4a145395c57f0c51f9b5dbfcd"},
+    {file = "orjson-3.11.8-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1cd0b77e77c95758f8e1100139844e99f3ccc87e71e6fc8e1c027e55807c549f"},
+    {file = "orjson-3.11.8-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:6a3d159d5ffa0e3961f353c4b036540996bf8b9697ccc38261c0eac1fd3347a6"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76070a76e9c5ae661e2d9848f216980d8d533e0f8143e6ed462807b242e3c5e8"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:54153d21520a71a4c82a0dbb4523e468941d549d221dc173de0f019678cf3813"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:469ac2125611b7c5741a0b3798cd9e5786cbad6345f9f400c77212be89563bec"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14778ffd0f6896aa613951a7fbf4690229aa7a543cb2bfbe9f358e08aafa9546"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea56a955056a6d6c550cf18b3348656a9d9a4f02e2d0c02cabf3c73f1055d506"},
+    {file = "orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53a0f57e59a530d18a142f4d4ba6dfc708dc5fdedce45e98ff06b44930a2a48f"},
+    {file = "orjson-3.11.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b48e274f8824567d74e2158199e269597edf00823a1b12b63d48462bbf5123e"},
+    {file = "orjson-3.11.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3f262401086a3960586af06c054609365e98407151f5ea24a62893a40d80dbbb"},
+    {file = "orjson-3.11.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8e8c6218b614badf8e229b697865df4301afa74b791b6c9ade01d19a9953a942"},
+    {file = "orjson-3.11.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:093d489fa039ddade2db541097dbb484999fcc65fc2b0ff9819141e2ab364f25"},
+    {file = "orjson-3.11.8-cp312-cp312-win32.whl", hash = "sha256:e0950ed1bcb9893f4293fd5c5a7ee10934fbf82c4101c70be360db23ce24b7d2"},
+    {file = "orjson-3.11.8-cp312-cp312-win_amd64.whl", hash = "sha256:3cf17c141617b88ced4536b2135c552490f07799f6ad565948ea07bef0dcb9a6"},
+    {file = "orjson-3.11.8-cp312-cp312-win_arm64.whl", hash = "sha256:48854463b0572cc87dac7d981aa72ed8bf6deedc0511853dc76b8bbd5482d36d"},
+    {file = "orjson-3.11.8-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:3f23426851d98478c8970da5991f84784a76682213cd50eb73a1da56b95239dc"},
+    {file = "orjson-3.11.8-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:ebaed4cef74a045b83e23537b52ef19a367c7e3f536751e355a2a394f8648559"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97c8f5d3b62380b70c36ffacb2a356b7c6becec86099b177f73851ba095ef623"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:436c4922968a619fb7fef1ccd4b8b3a76c13b67d607073914d675026e911a65c"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ab359aff0436d80bfe8a23b46b5fea69f1e18aaf1760a709b4787f1318b317f"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f89b6d0b3a8d81e1929d3ab3d92bbc225688bd80a770c49432543928fe09ac55"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:29c009e7a2ca9ad0ed1376ce20dd692146a5d9fe4310848904b6b4fee5c5c137"},
+    {file = "orjson-3.11.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:705b895b781b3e395c067129d8551655642dfe9437273211d5404e87ac752b53"},
+    {file = "orjson-3.11.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:88006eda83858a9fdf73985ce3804e885c2befb2f506c9a3723cdeb5a2880e3e"},
+    {file = "orjson-3.11.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:55120759e61309af7fcf9e961c6f6af3dde5921cdb3ee863ef63fd9db126cae6"},
+    {file = "orjson-3.11.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:98bdc6cb889d19bed01de46e67574a2eab61f5cc6b768ed50e8ac68e9d6ffab6"},
+    {file = "orjson-3.11.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:708c95f925a43ab9f34625e45dcdadf09ec8a6e7b664a938f2f8d5650f6c090b"},
+    {file = "orjson-3.11.8-cp313-cp313-win32.whl", hash = "sha256:01c4e5a6695dc09098f2e6468a251bc4671c50922d4d745aff1a0a33a0cf5b8d"},
+    {file = "orjson-3.11.8-cp313-cp313-win_amd64.whl", hash = "sha256:c154a35dd1330707450bb4d4e7dd1f17fa6f42267a40c1e8a1daa5e13719b4b8"},
+    {file = "orjson-3.11.8-cp313-cp313-win_arm64.whl", hash = "sha256:4861bde57f4d253ab041e374f44023460e60e71efaa121f3c5f0ed457c3a701e"},
+    {file = "orjson-3.11.8-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:ec795530a73c269a55130498842aaa762e4a939f6ce481a7e986eeaa790e9da4"},
+    {file = "orjson-3.11.8-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c492a0e011c0f9066e9ceaa896fbc5b068c54d365fea5f3444b697ee01bc8625"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:883206d55b1bd5f5679ad5e6ddd3d1a5e3cac5190482927fdb8c78fb699193b5"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5774c1fdcc98b2259800b683b19599c133baeb11d60033e2095fd9d4667b82db"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ac7381c83dd3d4a6347e6635950aa448f54e7b8406a27c7ecb4a37e9f1ae08b"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14439063aebcb92401c11afc68ee4e407258d2752e62d748b6942dad20d2a70d"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa72e71977bff96567b0f500fc5bfd2fdf915f34052c782a4c6ebbdaa97aa858"},
+    {file = "orjson-3.11.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7679bc2f01bb0d219758f1a5f87bb7c8a81c0a186824a393b366876b4948e14f"},
+    {file = "orjson-3.11.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14f7b8fcb35ef403b42fa5ecfa4ed032332a91f3dc7368fbce4184d59e1eae0d"},
+    {file = "orjson-3.11.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c2bdf7b2facc80b5e34f48a2d557727d5c5c57a8a450de122ae81fa26a81c1bc"},
+    {file = "orjson-3.11.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ccd7ba1b0605813a0715171d39ec4c314cb97a9c85893c2c5c0c3a3729df38bf"},
+    {file = "orjson-3.11.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdbc8c9c02463fef4d3c53a9ba3336d05496ec8e1f1c53326a1e4acc11f5c600"},
+    {file = "orjson-3.11.8-cp314-cp314-win32.whl", hash = "sha256:0b57f67710a8cd459e4e54eb96d5f77f3624eba0c661ba19a525807e42eccade"},
+    {file = "orjson-3.11.8-cp314-cp314-win_amd64.whl", hash = "sha256:735e2262363dcbe05c35e3a8869898022af78f89dde9e256924dc02e99fe69ca"},
+    {file = "orjson-3.11.8-cp314-cp314-win_arm64.whl", hash = "sha256:6ccdea2c213cf9f3d9490cbd5d427693c870753df41e6cb375bd79bcbafc8817"},
+    {file = "orjson-3.11.8.tar.gz", hash = "sha256:96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e"},
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+description = "Fast, correct Python msgpack library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b"},
+    {file = "ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c"},
+    {file = "ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4"},
+    {file = "ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9"},
+    {file = "ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f"},
+    {file = "ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d"},
+    {file = "ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2"},
+    {file = "ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33"},
 ]
 
 [[package]]
@@ -4519,6 +4829,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+description = "A utility belt for advanced users of python-requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+files = [
+    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
+    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
+]
+
+[package.dependencies]
+requests = ">=2.0.1,<3.0.0"
+
+[[package]]
 name = "resend"
 version = "2.27.0"
 description = "Resend Python SDK"
@@ -5040,6 +5365,22 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55"},
+    {file = "tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -5447,6 +5788,38 @@ brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "uuid-utils"
+version = "0.14.1"
+description = "Fast, drop-in replacement for Python's uuid module, powered by Rust."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:93a3b5dc798a54a1feb693f2d1cb4cf08258c32ff05ae4929b5f0a2ca624a4f0"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccd65a4b8e83af23eae5e56d88034b2fe7264f465d3e830845f10d1591b81741"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b56b0cacd81583834820588378e432b0696186683b813058b707aedc1e16c4b1"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb3cf14de789097320a3c56bfdfdd51b1225d11d67298afbedee7e84e3837c96"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e0854a90d67f4b0cc6e54773deb8be618f4c9bad98d3326f081423b5d14fae"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6743ba194de3910b5feb1a62590cd2587e33a73ab6af8a01b642ceb5055862"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:043fb58fde6cf1620a6c066382f04f87a8e74feb0f95a585e4ed46f5d44af57b"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c915d53f22945e55fe0d3d3b0b87fd965a57f5fd15666fd92d6593a73b1dd297"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0972488e3f9b449e83f006ead5a0e0a33ad4a13e4462e865b7c286ab7d7566a3"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1c238812ae0c8ffe77d8d447a32c6dfd058ea4631246b08b5a71df586ff08531"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bec8f8ef627af86abf8298e7ec50926627e29b34fa907fcfbedb45aaa72bca43"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b197cd5424cf89fb019ca7f53641d05bfe34b1879614bed111c9c313b5574cd8"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:12c65020ba6cb6abe1d57fcbfc2d0ea0506c67049ee031714057f5caf0f9bc9c"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b5d2ad28063d422ccc2c28d46471d47b61a58de885d35113a8f18cb547e25bf"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da2234387b45fde40b0fedfee64a0ba591caeea9c48c7698ab6e2d85c7991533"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50fffc2827348c1e48972eed3d1c698959e63f9d030aa5dd82ba451113158a62"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dbe718765f70f5b7f9b7f66b6a937802941b1cc56bcf642ce0274169741e01"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2"},
+    {file = "uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69"},
+]
 
 [[package]]
 name = "uvicorn"
@@ -5864,6 +6237,203 @@ files = [
 ]
 
 [[package]]
+name = "xxhash"
+version = "3.7.0"
+description = "Python binding for xxHash"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "xxhash-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd8ab85c916a58d5c8656ea15e3ce9df836fe2f120a74c296e01d69fab2614b4"},
+    {file = "xxhash-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:85f5c0e26d945b5bb475e0a3d95193117498130baa7619357bdc7869c2391b5a"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b7ffeaada9f8699be63d639536b0b60dff73b7d3325b7475c5bc8fdbf4eed47f"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee88dfaa6b1b2bfadd3c031fa5f05584870e62fb05dc500942e9900c44fcfda"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7426ff0dfa76eb47efc2cc59d4a717bfa9dc9938bff5e49e748bca749f6aa616"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8ff6ec73110f610425caef3ea875afbfc34caa542f01df3a80f45aadeb9f906"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0d23fd49fdc5c8af61fb7104f1ad247954499140f6cb6045b3aa5c99dadbbf28"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12c249621af6d50a05d9f10af894b404157b15819878e18f75fcbb0213a77d07"},
+    {file = "xxhash-3.7.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6741564a923f082f3c2941c8bb920462ed5b25eaebdd1e161f162233c9a10bc5"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4fd8acc6e32596350619896feb372033c0920975992d29837c32853bb1feacd"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:646a69b56d8145d85f7fd2289d14fba07880c8a5bda406aa256b407481a61f35"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:11dd69b1a34b7b9af29012f390825b0cdb0617c0966560e227ca74daa7478ba9"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:01cf5c5333aed26cc8d5eea33b8d6398e085e365a704b7372fabdf7ab06441a9"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f1e65d52c2d526734abecb98372c256b7eacce8fdc42e0df8570417fb39e2772"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8ff00fcc3eb436617ed8556cf15daf76c2b501248361a065625a588af78a0a02"},
+    {file = "xxhash-3.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b5cd29840505631c6f7dbb8a5d34b742b5e6bbda38fe0b9f54e825f3ea6b61dc"},
+    {file = "xxhash-3.7.0-cp310-cp310-win32.whl", hash = "sha256:5bf2f1940499839b39fef1561b5ecb6ede9ac34ef4457474e1337fc7ef07c2f3"},
+    {file = "xxhash-3.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:d41fcda2fa8ca682ebca134a2f2dc02575ba549267585597e73061565795f475"},
+    {file = "xxhash-3.7.0-cp310-cp310-win_arm64.whl", hash = "sha256:a845a59664d5c531525a467470220f8edc37959e0a6f8e734ffb6654da5c4bee"},
+    {file = "xxhash-3.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fdc7d06929ae28dda98297a18eef7b0fd38991a3b405d8d7b55c9ef24c296958"},
+    {file = "xxhash-3.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea6daa712f4e094a30830cf01e9b47d03b24d05cc9dab8609f0d9a9db8454712"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9e6c0d843f1daf85ea23aeb053579135552bde575b7b98af20bfc667b6e4548d"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:363c139bf15e1ac5f136b981d3c077eb551299b1effede7f12faa010b8590a60"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a778b25874cb0f862eaab5986bff4ca49ffb0def7c0a34c237b948b3c6c775b2"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e1860f1e43d40e9d904cf22d93e587ea42e010ebce4160877e46bcab4bc232a"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9122ad6f867c4a0f5e655f5c3bdf89103852009dbb442a3d23e688b9e699e800"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d9110d0c3fb02679972837a033251fd186c529aa62f19c132fc909c74052b8"},
+    {file = "xxhash-3.7.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:347a93f2b4ce67ce61959665e32a7447c380f8347e55e100daa23766baacf0e5"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:acbb48679ddf3852c45280c10ff10d52ca2cd1da2e552fb81db1ff786c75d0e4"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:fe14c356f8b23ad811dc026077a6d4abccdaa7bce5ca98579605550657b6fcfb"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f420ad3d41e38194353a498bbc9561fd5a9973a27b536ce46d8583479cf44335"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:693d02c6dc7d1aa0a45921d54cd8c1ff629e09dfdc2238471507af1f7a1c6f04"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:14bf7a54e43825ec131ee7fe3c60e142e7c2c1e676ad0f93fc893432d15414af"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ae3a39a4d96bdb6f8d154fd7f490c4ad06f0532fcd2bb656052a9a7762cf5d31"},
+    {file = "xxhash-3.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1cc07c639e3a77ef1d32987464d3e408565b8a3be57b545d3542b191054d9923"},
+    {file = "xxhash-3.7.0-cp311-cp311-win32.whl", hash = "sha256:3281ba1d1e60ee7a382a7b958513ba03c2c0d5fcbd9a6f7517c0a81251a23422"},
+    {file = "xxhash-3.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:a7f25baec4c5d851d40718d6fae52285b31683093d4ff5207e63ab306ccf14a5"},
+    {file = "xxhash-3.7.0-cp311-cp311-win_arm64.whl", hash = "sha256:4c2454448ce847c72635827bb75c15c5a3434b03ee1afd28cb6dc6fb2597d830"},
+    {file = "xxhash-3.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:082c87bfdd2b9f457606c7a4a53457f4c4b48b0cdc48de0277f4349d79bb3d7a"},
+    {file = "xxhash-3.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5e7ce913b61f35b0c1c839a49ac9c8e75dd8d860150688aed353b0ce1bf409d8"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3beb1de3b1e9694fcdd853e570ee64c631c7062435d2f8c69c1adf809bc086f0"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3e7b689c3bce16699efcf736066f5c6cc4472c3840fe4b22bd8279daf4abdac"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a6545e6b409e3d5cbafc850fb84c55a1ca26ed15a6b11e3bf07a0e0cd84517c8"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:31ab1461c77a11461d703c88eb949e132a1c6515933cf675d97ec680f4bd18de"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c4d596b7676f811172687ec567cbafb9e4dea2f9be1bbb4f622410cb7f40f40"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13805f0461cba0a857924e70ff91ae6d52d2598f79a884e788db80532614a4a1"},
+    {file = "xxhash-3.7.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d398f372496152f1c6933a33566373f8d1b37b98b8c9d608fa6edc0976f23b2"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d610aa62cdb7d4d497740741772a24a794903bf3e79eaa51d2e800082abe11e5"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:073c23900a9fbf3d26616c17c830db28af9803677cd5b33aea3224d824111514"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:418a463c3e6a590c0cdc890f8be19adb44a8c8acd175ca5b2a6de77e61d0b386"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:03f8ff4474ee61c845758ce00711d7087a770d77efb36f7e74a6e867301000b8"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:44fba4a5f1d179b7ddc7b3dc40f56f9209046421679b57025d4d8821b376fd8d"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31e3516a0f829d06ded4a2c0f3c7c5561993256bfa1c493975fb9dc7bfa828a1"},
+    {file = "xxhash-3.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b59ee2ac81de57771a09ecad09191e840a1d2fae1ef684208320591055768f83"},
+    {file = "xxhash-3.7.0-cp312-cp312-win32.whl", hash = "sha256:74bbd92f8c7fcc397ba0a11bfdc106bc72ad7f11e3a60277753f87e7532b4d81"},
+    {file = "xxhash-3.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:7bd7bc82dd4f185f28f35193c2e968ef46131628e3cac62f639dadf321cba4d1"},
+    {file = "xxhash-3.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:7d7148180ec99ba36585b42c8c5de25e9b40191613bc4be68909b4d25a77a852"},
+    {file = "xxhash-3.7.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:4b6d6b33f141158692bd4eafbb96edbc5aa0dabdb593a962db01a91983d4f8fa"},
+    {file = "xxhash-3.7.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:845d347df254d6c619f616afa921331bada8614b8d373d58725c663ba97c3605"},
+    {file = "xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:fddbbb69a6fff4f421e7a0d1fa28f894b20112e9e3fab306af451e2dfd0e459b"},
+    {file = "xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:54876a4e45101cec2bf8f31a973cda073a23e2e108538dad224ba07f85f22487"},
+    {file = "xxhash-3.7.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:0c72fe9c7e3d6dfd7f1e21e224a877917fa09c465694ba4e06464b9511b65544"},
+    {file = "xxhash-3.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a6d73a830b17ef49bc04e00182bd839164c1b3c59c127cd7c54fcb10c7ed8ee8"},
+    {file = "xxhash-3.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c3b07cf3362086d8f126c6aecd8e5e9396ad8b2f2219ea7e49a8250c318acd"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:50e879ebbac351c81565ca108db766d7832f5b8b6a5b14b8c0151f7190028e3d"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:921c14e93817842dd0dd9f372890a0f0c72e534650b6ab13c5be5cd0db11d47e"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e64a7c9d7dfca3e0fafcbc5e455519090706a3e36e95d655cec3e04e79f95aaa"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2220af08163baf5fa36c2b8af079dc2cbe6e66ae061385267f9472362dfd53c6"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f14bb8b22a4a91325813e3d553b8963c10cf8c756cff65ee50c194431296c655"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496736f86a9bedaf64b0dc70e3539d0766df01c71ea22032698e88f3f04a1ce9"},
+    {file = "xxhash-3.7.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0ff71596bd79816975b3de7130ab1ff4541410285a3c084584eeb1c8239996fd"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1ad86695c19b1d46fe106925db3c7a37f16be37669dcf58dcc70a9dd6e324676"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:970f9f8c50961d639cbd0d988c96f80ddf66006de93641719282c4fe7a87c5e6"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5886ad85e9e347911783760a1d16cb6b393e8f9e3b52c982568226cb56927bdc"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6e934bbae1e0ec74e27d5f0d7f37ef547ce5ff9f0a7e63fb39e559fc99526734"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:3b6b3d28228af044ebcded71c4a3dd86e1dbd7e2f4645bf40f7b5da65bb5fb5a"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:6be4d70d9ab76c9f324ead9c01af6ff52c324745ea0c3731682a0cf99720f1fe"},
+    {file = "xxhash-3.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:151d7520838d4465461a0b7f4ae488b3b00de16183dd3214c1a6b14bf89d7fb6"},
+    {file = "xxhash-3.7.0-cp313-cp313-win32.whl", hash = "sha256:d798c1e291bffb8e37b5bbe0dda77fc767cd19e89cadaf66e6ed5d0ff88c9fe6"},
+    {file = "xxhash-3.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:875811ba23c543b1a1c3143c926e43996eb27ebb8f52d3500744aa608c275aed"},
+    {file = "xxhash-3.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:54a675cb300dda83d71daae2a599389d22db8021a0f8db0dd659e14626eb3ecc"},
+    {file = "xxhash-3.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a3b19a42111c4057c1547a4a1396a53961dca576a0f6b82bfa88a2d1561764b2"},
+    {file = "xxhash-3.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8f4608a06e4d61b7a3425665a46d00e0579122e1a2fae97a0c52953a3aad9aa3"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ad37c7792479e49cf96c1ab25517d7003fe0d93687a772ba19a097d235bbe41e"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc026e3b89d98e30a8288c95cb696e77d150b3f0fb7a51f73dcd49ee6b5577fa"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c9b31ab1f28b078a6a1ac1a54eb35e7d5390deddd56870d0be3a0a733d1c321c"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3bb5fd680c038fd5229e44e9c493782f90df9bef632fd0499d442374688ff70b"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:030c0fd688fce3569fbb49a2feefd4110cbb0b650186fb4610759ecfac677548"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b1bde10324f4c31812ae0d0502e92d916ae8917cad7209353f122b8b8f610c3"},
+    {file = "xxhash-3.7.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:503722d52a615f2604f5e7611de7d43878df010dc0053094ef91cb9a9ac3d987"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c72500a3b6d6c30ebfc135035bcace9eb5884f2dc220804efcaaba43e9f611dd"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:43475925a766d01ca8cd9a857fd87f3d50406983c8506a4c07c4df12adcc867f"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8d09dfd2ab135b985daf868b594315ebe11ad86cd9fea46e6c69f19b28f7d25a"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c50269d0055ac1faecfd559886d2cbe4b730de236585aba0e873f9d9dadbe585"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1910df4756a5ab58cfad8744fc2d0f23926e3efcc346ee76e87b974abab922f4"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d006faf3b491957efcb433489be3c149efe4787b7063d5cddb8ddaefdc60e0c1"},
+    {file = "xxhash-3.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:abb65b4e947e958f7b3b0d71db3ce447d1bc5f37f5eab871ce7223bda8768a04"},
+    {file = "xxhash-3.7.0-cp313-cp313t-win32.whl", hash = "sha256:178959906cb1716a1ce08e0d69c82886c70a15a6f2790fc084fdd146ca30cd49"},
+    {file = "xxhash-3.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2524a1e20d4c231d13b50f7cf39e44265b055669a64a7a4b9a2a44faa03f19b6"},
+    {file = "xxhash-3.7.0-cp313-cp313t-win_arm64.whl", hash = "sha256:37d994d0ffe81ef087bb330d392caa809bb5853c77e22ea3f71db024a0543dba"},
+    {file = "xxhash-3.7.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:8c5fcfd806c335bfa2adf1cd0b3110a44fc7b6995c3a648c27489bae85801465"},
+    {file = "xxhash-3.7.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:506a0b488f190f0a06769575e30caf71615c898ed93ab18b0dbcb6dec5c3713c"},
+    {file = "xxhash-3.7.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:ec68dbba21532c0173a9872298e65c89749f7c9d21538c3a78b5bb6105871568"},
+    {file = "xxhash-3.7.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:fa77e7ec1450d415d20129961814787c9abd9a07f98872f070b1fe96c5084611"},
+    {file = "xxhash-3.7.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:fe32736295ea38e43e7d9424053c8c47c9f64fecfc7c895fb3da9b30b131c9ee"},
+    {file = "xxhash-3.7.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ab9dd2c83c4bbd63e422181a76f13502d049d3ddcac9a1bdc29196263d692bb8"},
+    {file = "xxhash-3.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3afec3a336a2286601a437cb07562ab0227685e6fbb9ec17e8c18457ff348ecf"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:565df64437a9390f84465dcca33e7377114c7ede8d05cd2cf20081f831ea788e"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12eca820a5d558633d423bf8bb78ce72a55394823f64089247f788a7e0ae691e"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f262b8f7599516567e070abf607b9af649052b2c4bd6f9be02b0cb41b7024805"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1598916cb197681e03e601901e4ab96a9a963de398c59d0964f8a6f44a2b361"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:322b2f0622230f526aeb1738149948a7ae357a9e2ceb1383c6fd1fdaecdafa16"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24cc22070880cc57b830a65cde4e65fa884c6d9b28ae4803b5ee05911e7bafba"},
+    {file = "xxhash-3.7.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb5a888a968b2434abf9ecda357b5d43f10d7b5a6da6fdbbe036208473aff0e2"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a999771ff97bec27d18341be4f3a36b163bb1ac41ec17bef6d2dabd84acd33c7"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ed4a6efe2dee1655adb73e7ad40c6aa955a6892422b1e3b95de6a34de56e3cbb"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9fd17f14ac0faa12126c2f9ca774a8cf342957265ec3c8669c144e5e6cdb478c"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:05fd1254268c59b5cb2a029dfc204275e9fc52de2913f1e53aa8d01442c96b4d"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a2eae53197c6276d5b317f75a1be226bbf440c20b58bf525f36b5d0e1f657ca6"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bfe6f92e3522dcbe8c4281efd74fa7542a336cb00b0e3272c4ec0edabeaeaf67"},
+    {file = "xxhash-3.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7ab9a49c410d8c6c786ab99e79c529938d894c01433130353dd0fe999111077a"},
+    {file = "xxhash-3.7.0-cp314-cp314-win32.whl", hash = "sha256:040ea63668f9185b92bc74942df09c7e65703deed71431333678fc6e739a9955"},
+    {file = "xxhash-3.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:2a61e2a3fb23c892496d587b470dee7fa1b58b248a187719c65ea8e94ec13257"},
+    {file = "xxhash-3.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:c7741c7524961d8c0cb4d4c21b28957ff731a3fd5b5cd8b856dc80a40e9e5acc"},
+    {file = "xxhash-3.7.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc84bf7aa7592f31ec63a3e7b11d624f468a3f19f5238cec7282a42e838ab1d7"},
+    {file = "xxhash-3.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9f1563fdc8abfc389748e6932c7e4e99c89a53e4ec37d4563c24fc06f5e5644b"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2d415f18becf6f153046ab6adc97da77e3643a0ee205dae61c4012604113a020"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb16aa13ed175bc9be5c2491ba031b85a9b51c4ed90e0b3d4ebe63cf3fb54f8e"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f9fd595f1e5941b3d7863e4774e4b30caa6731fc34b9277da032295aa5656ee5"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1295325c5a98d552333fa53dc2b026b0ef0ec9c8e73ca3a952990b4c7d65d459"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3573a651d146912da9daa9e29e5fbc45994420daaa9ef1e2fa5823e1dc485513"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ec1e080a3d02d94ea9335bfab0e3374b877e25411422c18f51a943fa4b46381"},
+    {file = "xxhash-3.7.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84415265192072d8638a3afc3c1bc5995e310570cd9acb54dc46d3939e364fe0"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d4dea659b57443989ef32f4295104fd6912c73d0bf26d1d148bb88a9f159b02"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:05ece0fe4d9c9c2728912d1981ae1566cfc83a011571b24732cbf76e1fb70dca"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:fd880353cf1ffaf321bc18dd663e111976dbd0d3bbd8a66d58d2b470dfa7f396"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4e15cc9e2817f6481160f930c62842b3ff419e20e13072bcbab12230943092bc"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:90b9d1a8bd37d768ffc92a1f651ec69afc532a96fa1ac2ea7abbed5d630b3237"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:157c49475b34ecea8809e51123d9769a534e139d1247942f7a4bc67710bb2533"},
+    {file = "xxhash-3.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5a6ddec83325685e729ca119d1f5c518ec39294212ecd770e60693cdc5f7eb79"},
+    {file = "xxhash-3.7.0-cp314-cp314t-win32.whl", hash = "sha256:a04a6cab47e2166435aaf5b9e5ee41d1532cc8300efdef87f2a4d0acb7db19ed"},
+    {file = "xxhash-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8653dd7c2eda020545bb2c71c7f7039b53fe7434d0fc1a0a9deb79ab3f1a4fc1"},
+    {file = "xxhash-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:468f0fc114faaa4b36699f8e328bbc3bb11dc418ba94ac52c26dd736d4b6c637"},
+    {file = "xxhash-3.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:153c3a4f73563101d4c8102cbff6a5b46f7aa9dbe374eedf1cd3b15fda750566"},
+    {file = "xxhash-3.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c21625d710f971dd58ae92c5b0c2ca109d2ceba939becc937c5cff9268cd451b"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fe820f104473d1516ecd628993690bc1f79b0e699f32711d42a5a70b3d0f8170"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c40a8ad7d42fe779ac429fe245ed44c54f30e2549173559d70b7167922431701"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6e83179bbb208fb72774c06ba227d6e410fa3797de33d0d4c00e3935f81da7d2"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3c0059e642b2e7e15c77341a8946f670a403fcd57feecc9e47d68555b9b1c08"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c76f18d1268d3dc1c8b8facef5b48a9c6172d4a49113afa2d91745f555c75ff"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17f8ae90c8e00f225be4899c3023704f23ee6d5638a00c54d6cbe9980068e6f9"},
+    {file = "xxhash-3.7.0-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:50846b9b01f461ee0250d7a701a3d881e9c52ebce335d6e38e0224adc3369f50"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:79f9efdbc828b02c681a7cefc6d4108d63811b20a8fb8518a40cb2c13ed15452"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:b081119a6115d2db49e24ab6316b7dcd74651271e9630c7b979999bd0c11973d"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:d33fcd60f5546e4b7538a8ae2b2027b51e9905b9a264c32df56de32202997155"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:1061bc6cec00adf75347b064ee62b220d66d9bc506acaad1418c79eec45a318c"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:b4e6fe5c6f4e6ad67c1374a7c85c944ca1a8d9672f0a1628201ea5c58e0d4596"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:7553816512c0abb75329c163a1eee77b0802c3757054b910d6e547bd0dbd16b7"},
+    {file = "xxhash-3.7.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:f749e52b539e2934171a3718cbf061dc12d74719eddde2d0f025c99637ddbe01"},
+    {file = "xxhash-3.7.0-cp38-cp38-win32.whl", hash = "sha256:6f31143e18e6db136455b16f0e4e6eba943e1889127dd7c649b46a50d54dd836"},
+    {file = "xxhash-3.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:dea2fd4ae84b14aa883ac713faffbb5c26764ec623e00ed34737895be523d1fa"},
+    {file = "xxhash-3.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f13319fb8e6ef636f71db3c254d01cbf1543786e10a945a3ff180144618e25b6"},
+    {file = "xxhash-3.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ca12a6d683957a651e3203c1458ff8ab4119aae7363e202e2e820cbfe02df244"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:646b8aa66cf0cec9295dfc4e3ac823ee52e338bada9547f5cf2d674212d04b58"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f99a15867cbf9fcf753ea72b82a1d6fe6552e6feea3b4842c86a951525685bbb"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:84710b4e449596a6565ab67293858d2d93a54eeec55722d55c8f0a08b6e6de24"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:44909f79fb7a4950ec7d96059398f46f634534cd95be9330a3827210af5aaebe"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da5b373b1dfce210b8620bdb5d9dae668fe549de67948465dcc39e833d4bbe28"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:421da671f43a0189b57a4b8be694576308395f92f55ed3badcde67ab95acef81"},
+    {file = "xxhash-3.7.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c36f89ba026ccc6fde8f48479a2fd9fc450a736cc7c0d5650acfcff8636282e"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ea85a647fd33d5cf2840027c2e0b7da8868b220d3f05e3866efdda78c440d499"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:6318d8b6f6c6c21058928c23289686fc74f37d794170f14b35fecceb515d5e37"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce1e2782efaf0f595c17fe331cf295882a268c04d5887956e2fc0d262b0fb3a"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:49e556558eee5c8c9b2d5da03fd36cfa6c99cae95b3c3887ec64ee1a49ed517a"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:cf7424a11a81f59b6f0abdccfbe27c87d552f059ef761471f98245b46b71b5c9"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:8e7edb98dd4721a2694542a35a0bdb989b42892086fd0216f7c48762dfe20844"},
+    {file = "xxhash-3.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d1442628c84afa453a9a06a10d74d890d3c1b1e4da313b48b16e1001895fdac4"},
+    {file = "xxhash-3.7.0-cp39-cp39-win32.whl", hash = "sha256:dbcd969178d417c2bbd60076f8e407a0e2baf90976eed21c1b818ff8292b902f"},
+    {file = "xxhash-3.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:3409b50ddbc76377d938f40a7a4662cd449f743f2c6178fd6162b875bf9b0d4f"},
+    {file = "xxhash-3.7.0-cp39-cp39-win_arm64.whl", hash = "sha256:49a88183a3e5ab0b69d9bbfc0180cbdb247e8bada19fd9403c538b3aa3c24176"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ad3aa71e12ee634f22b39a0ff439357583706e50765f17f05550f92dbf128a23"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5de686e73690cdaf72b96d4fa083c230ec9020bcc2627ce6316138e2cf2fe2d1"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7fbec49f5341bbdea0c471f7d1e2fb41ae8925af9b6f28025c28defd8eb94274"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b542c347c2089f43dc5a6db31d2a6f3cdb04ee33505ec6e9f653834dbb0bde"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a169a036bed0995e090d1493b283cc2cc8a6f5046821086b843abefff80643bc"},
+    {file = "xxhash-3.7.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ec101643395d7f21405b640f728f6f627e6986557027d740f2f9b220955edafe"},
+    {file = "xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.23.0"
 description = "Yet another URL library"
@@ -6027,6 +6597,118 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd"},
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:ab85470ab54c2cb96e176f40342d9ed41e58ca5733be6a893b730e7af9c40550"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e05ab82ea7753354bb054b92e2f288afb750e6b439ff6ca78af52939ebbc476d"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:78228d8a6a1c177a96b94f7e2e8d012c55f9c760761980da16ae7546a15a8e9b"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b6bd67528ee8b5c5f10255735abc21aa106931f0dbaf297c7be0c886353c3d0"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b6d83057e713ff235a12e73916b6d356e3084fd3d14ced499d84240f3eecee0"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9174f4ed06f790a6869b41cba05b43eeb9a35f8993c4422ab853b705e8112bbd"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25f8f3cd45087d089aef5ba3848cd9efe3ad41163d3400862fb42f81a3a46701"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3756b3e9da9b83da1796f8809dd57cb024f838b9eeafde28f3cb472012797ac1"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81dad8d145d8fd981b2962b686b2241d3a1ea07733e76a2f15435dfb7fb60150"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a5a419712cf88862a45a23def0ae063686db3d324cec7edbe40509d1a79a0aab"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e7360eae90809efd19b886e59a09dad07da4ca9ba096752e61a2e03c8aca188e"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:75ffc32a569fb049499e63ce68c743155477610532da1eb38e7f24bf7cd29e74"},
+    {file = "zstandard-0.25.0-cp310-cp310-win32.whl", hash = "sha256:106281ae350e494f4ac8a80470e66d1fe27e497052c8d9c3b95dc4cf1ade81aa"},
+    {file = "zstandard-0.25.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea9d54cc3d8064260114a0bbf3479fc4a98b21dffc89b3459edd506b69262f6e"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7"},
+    {file = "zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa"},
+    {file = "zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf"},
+    {file = "zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088"},
+    {file = "zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d"},
+    {file = "zstandard-0.25.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b9af1fe743828123e12b41dd8091eca1074d0c1569cc42e6e1eee98027f2bbd0"},
+    {file = "zstandard-0.25.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b14abacf83dfb5c25eb4e4a79520de9e7e205f72c9ee7702f91233ae57d33a2"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:a51ff14f8017338e2f2e5dab738ce1ec3b5a851f23b18c1ae1359b1eecbee6df"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3b870ce5a02d4b22286cf4944c628e0f0881b11b3f14667c1d62185a99e04f53"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:05353cef599a7b0b98baca9b068dd36810c3ef0f42bf282583f438caf6ddcee3"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19796b39075201d51d5f5f790bf849221e58b48a39a5fc74837675d8bafc7362"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:53e08b2445a6bc241261fea89d065536f00a581f02535f8122eba42db9375530"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1f3689581a72eaba9131b1d9bdbfe520ccd169999219b41000ede2fca5c1bfdb"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d8c56bb4e6c795fc77d74d8e8b80846e1fb8292fc0b5060cd8131d522974b751"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:53f94448fe5b10ee75d246497168e5825135d54325458c4bfffbaafabcc0a577"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c2ba942c94e0691467ab901fc51b6f2085ff48f2eea77b1a48240f011e8247c7"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:07b527a69c1e1c8b5ab1ab14e2afe0675614a09182213f21a0717b62027b5936"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:51526324f1b23229001eb3735bc8c94f9c578b1bd9e867a0a646a3b17109f388"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89c4b48479a43f820b749df49cd7ba2dbc2b1b78560ecb5ab52985574fd40b27"},
+    {file = "zstandard-0.25.0-cp39-cp39-win32.whl", hash = "sha256:1cd5da4d8e8ee0e88be976c294db744773459d51bb32f707a0f166e5ad5c8649"},
+    {file = "zstandard-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:37daddd452c0ffb65da00620afb8e17abd4adaae6ce6310702841760c2c26860"},
+    {file = "zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b"},
+]
+
+[package.extras]
+cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
+
 [extras]
 ml = ["diffusers", "torch", "transformers"]
 profiling = ["pyroscope-io"]
@@ -6034,4 +6716,4 @@ profiling = ["pyroscope-io"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "539c77d5d2a8e3dc9137e20f78c83e8129bfc15669359481de768979974e27f4"
+content-hash = "916c9bc077b2dacafd7509b266cb6bdc229994a922373a198d108ca1ec3b06a3"

--- a/src/cofounder_agent/poindexter/cli/app.py
+++ b/src/cofounder_agent/poindexter/cli/app.py
@@ -14,6 +14,7 @@ from .settings import settings_group
 from .setup import setup_command
 from .sprint import sprint_group
 from .tasks import tasks_group
+from .topics import topics_group
 from .vercel import vercel_group
 
 # Quiet down the client's own info-level logs unless the user asks for -v.
@@ -47,6 +48,7 @@ main.add_command(costs_group, name="costs")
 main.add_command(sprint_group, name="sprint")
 main.add_command(vercel_group, name="vercel")
 main.add_command(premium_group, name="premium")
+main.add_command(topics_group, name="topics")
 
 
 if __name__ == "__main__":

--- a/src/cofounder_agent/poindexter/cli/topics.py
+++ b/src/cofounder_agent/poindexter/cli/topics.py
@@ -1,0 +1,301 @@
+"""``poindexter topics`` — operator commands for the niche topic-discovery batch.
+
+Wraps ``services.topic_batch_service.TopicBatchService`` and
+``services.niche_service.NicheService`` so the operator can:
+
+- ``poindexter topics show-batch --niche <slug>``  — peek at the open batch
+- ``poindexter topics rank-batch <id> --order ...`` — set operator ranking
+- ``poindexter topics edit-winner <id> [--topic ...] [--angle ...]``
+                                                    — override the rank-1 row
+- ``poindexter topics resolve-batch <id>``         — advance rank-1 to pipeline
+- ``poindexter topics reject-batch <id> [--reason ...]`` — discard the batch
+
+Plus a ``niche`` subgroup for read-only inspection of niche configuration:
+
+- ``poindexter topics niche list``   — every active niche
+- ``poindexter topics niche show <slug>`` — full config as JSON
+
+The CLI is the canonical operator surface; MCP tools and any future
+REST endpoints call into the same service modules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import click
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers — same env-var ladder used by the rest of the poindexter CLI.
+# ---------------------------------------------------------------------------
+
+
+def _dsn() -> str:
+    """Resolve the PostgreSQL DSN from the standard env-var ladder."""
+    dsn = (
+        os.getenv("POINDEXTER_MEMORY_DSN")
+        or os.getenv("LOCAL_DATABASE_URL")
+        or os.getenv("DATABASE_URL")
+        or ""
+    )
+    if not dsn:
+        raise RuntimeError(
+            "No DSN — set POINDEXTER_MEMORY_DSN, LOCAL_DATABASE_URL, or DATABASE_URL."
+        )
+    return dsn
+
+
+# ---------------------------------------------------------------------------
+# Group root
+# ---------------------------------------------------------------------------
+
+
+@click.group(
+    name="topics",
+    help=(
+        "Operator commands for the niche topic-discovery batch.\n\n"
+        "Drives the discover -> rank -> batch -> gate flow exposed by "
+        "``services.topic_batch_service.TopicBatchService``."
+    ),
+)
+def topics_group() -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# topics show-batch
+# ---------------------------------------------------------------------------
+
+
+@topics_group.command("show-batch")
+@click.option("--niche", required=True, help="Niche slug.")
+def show_batch(niche: str) -> None:
+    """Show the current open batch for a niche."""
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+        from services.topic_batch_service import TopicBatchService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            n = await NicheService(pool).get_by_slug(niche)
+            if not n:
+                raise click.ClickException(f"unknown niche: {niche}")
+            async with pool.acquire() as conn:
+                bid = await conn.fetchval(
+                    "SELECT id FROM topic_batches "
+                    "WHERE niche_id = $1 AND status = 'open'",
+                    n.id,
+                )
+            if bid is None:
+                click.echo(f"No open batch for niche {niche}.")
+                return
+            view = await TopicBatchService(pool).show_batch(batch_id=bid)
+            click.echo(f"Batch {view.id} (status={view.status})")
+            for c in view.candidates:
+                marker = (
+                    f"#{c.operator_rank}"
+                    if c.operator_rank
+                    else f"sys#{c.rank_in_batch}"
+                )
+                click.echo(
+                    f"  {marker:6s} [{c.kind:8s}] "
+                    f"eff={c.effective_score:5.1f} — {c.title}"
+                )
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+# ---------------------------------------------------------------------------
+# topics rank-batch
+# ---------------------------------------------------------------------------
+
+
+@topics_group.command("rank-batch")
+@click.argument("batch_id")
+@click.option(
+    "--order",
+    required=True,
+    help="Comma-separated candidate ids in your preferred order, best-first.",
+)
+def rank_batch(batch_id: str, order: str) -> None:
+    """Set operator ranking for a batch's candidates."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+
+        ids = [s.strip() for s in order.split(",") if s.strip()]
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).rank_batch(
+                batch_id=batch_id, ordered_candidate_ids=ids,
+            )
+            click.echo(f"Ranked {len(ids)} candidates in batch {batch_id}")
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+# ---------------------------------------------------------------------------
+# topics edit-winner
+# ---------------------------------------------------------------------------
+
+
+@topics_group.command("edit-winner")
+@click.argument("batch_id")
+@click.option("--topic", help="Override the winner's title.")
+@click.option("--angle", help="Override the winner's angle/summary.")
+def edit_winner(batch_id: str, topic: str | None, angle: str | None) -> None:
+    """Edit the title/angle of the rank-1 candidate before resolution."""
+    if not topic and not angle:
+        raise click.UsageError("Provide --topic and/or --angle.")
+
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).edit_winner(
+                batch_id=batch_id, topic=topic, angle=angle,
+            )
+            click.echo("Edited winner.")
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+# ---------------------------------------------------------------------------
+# topics resolve-batch
+# ---------------------------------------------------------------------------
+
+
+@topics_group.command("resolve-batch")
+@click.argument("batch_id")
+def resolve_batch(batch_id: str) -> None:
+    """Resolve a batch — advance the rank-1 candidate to the pipeline."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).resolve_batch(batch_id=batch_id)
+            click.echo(f"Resolved {batch_id}")
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+# ---------------------------------------------------------------------------
+# topics reject-batch
+# ---------------------------------------------------------------------------
+
+
+@topics_group.command("reject-batch")
+@click.argument("batch_id")
+@click.option("--reason", default="", help="Optional reason text.")
+def reject_batch(batch_id: str, reason: str) -> None:
+    """Reject a batch — discard candidates, allow a fresh sweep."""
+    async def _impl():
+        import asyncpg
+        from services.topic_batch_service import TopicBatchService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            await TopicBatchService(pool).reject_batch(
+                batch_id=batch_id, reason=reason,
+            )
+            click.echo(f"Rejected {batch_id}")
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+# ---------------------------------------------------------------------------
+# topics niche subgroup
+# ---------------------------------------------------------------------------
+
+
+@topics_group.group("niche")
+def niche_group() -> None:
+    """Manage niche configurations."""
+    pass
+
+
+@niche_group.command("list")
+def niche_list() -> None:
+    """List every active niche."""
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            for n in await NicheService(pool).list_active():
+                click.echo(
+                    f"{n.slug:20s} {n.name:30s} mode={n.writer_rag_mode}"
+                )
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+@niche_group.command("show")
+@click.argument("slug")
+def niche_show(slug: str) -> None:
+    """Print full niche config (slug, goals, sources) as JSON."""
+    async def _impl():
+        import asyncpg
+        from services.niche_service import NicheService
+
+        pool = await asyncpg.create_pool(_dsn(), min_size=1, max_size=2)
+        try:
+            svc = NicheService(pool)
+            n = await svc.get_by_slug(slug)
+            if not n:
+                raise click.ClickException(f"unknown niche: {slug}")
+            click.echo(
+                json.dumps(
+                    {
+                        "slug": n.slug,
+                        "name": n.name,
+                        "active": n.active,
+                        "writer_rag_mode": n.writer_rag_mode,
+                        "batch_size": n.batch_size,
+                        "discovery_cadence_minute_floor":
+                            n.discovery_cadence_minute_floor,
+                        "audience_tags": n.target_audience_tags,
+                        "goals": [
+                            {"type": g.goal_type, "weight": g.weight_pct}
+                            for g in await svc.get_goals(n.id)
+                        ],
+                        "sources": [
+                            {
+                                "name": s.source_name,
+                                "enabled": s.enabled,
+                                "weight": s.weight_pct,
+                            }
+                            for s in await svc.get_sources(n.id)
+                        ],
+                    },
+                    indent=2,
+                )
+            )
+        finally:
+            await pool.close()
+
+    asyncio.run(_impl())
+
+
+__all__ = ["topics_group"]

--- a/src/cofounder_agent/pyproject.toml
+++ b/src/cofounder_agent/pyproject.toml
@@ -86,6 +86,7 @@ prometheus-client = "^0.25.0"
 # Continuous profiling — LGTM+P stack (GH #75). Opt-in via app_settings
 # enable_pyroscope; services/profiling.py configures the agent.
 pyroscope-io = { version = "^0.8.5", optional = true }
+langgraph = ">=0.2,<1.0"
 
 [tool.poetry.extras]
 ml = ["torch", "transformers", "diffusers"]

--- a/src/cofounder_agent/services/ai_content_generator.py
+++ b/src/cofounder_agent/services/ai_content_generator.py
@@ -1041,5 +1041,70 @@ async def test_generation():
     logger.info("First 500 characters:\n%s...", content[:500])
 
 
+# ---------------------------------------------------------------------------
+# Writer-RAG-mode helpers (Task 14 of the niche-discovery RAG pivot)
+# ---------------------------------------------------------------------------
+#
+# The four writer modes in services/writer_rag_modes/* call into these two
+# functions to render a draft from a topic + angle + retrieved snippets.
+# They are deliberately thin wrappers around _ollama_chat_json so unit tests
+# can monkeypatch this module to avoid a real Ollama call.
+#
+# Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+# Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 14)
+
+
+async def generate_with_context(
+    *, topic: str, angle: str, snippets: list[dict],
+    extra_instructions: str | None = None,
+) -> str:
+    """Build a prompt using the snippets as background context, generate the
+    draft. Wraps the existing generation path; tests can monkeypatch here."""
+    snippet_block = "\n".join(
+        f"[{s['source']}/{s['ref']}] {s['snippet'][:500]}"
+        for s in snippets if s.get('snippet')
+    )
+    instructions = extra_instructions or ""
+    from services.topic_ranking import _ollama_chat_json
+    prompt = f"""Write a blog post on the topic: "{topic}" with this angle: "{angle}".
+
+{instructions}
+
+Background context (cite where relevant):
+{snippet_block}
+
+Return the full post body in Markdown.
+"""
+    return await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+
+
+async def generate_with_outline(
+    *, topic: str, outline: dict, snippets: list[dict],
+) -> str:
+    """Expand a structured outline into a full blog post draft.
+
+    Used by the STORY_SPINE writer mode after it preprocesses the top
+    snippets into a {hook, what_happened, why_it_matters, ...} skeleton.
+    """
+    snippet_block = "\n".join(
+        f"[{s['source']}/{s['ref']}] {s['snippet'][:500]}"
+        for s in snippets if s.get('snippet')
+    )
+    outline_block = "\n".join(f"{k.replace('_',' ').title()}: {v}" for k, v in outline.items())
+    from services.topic_ranking import _ollama_chat_json
+    prompt = f"""Expand the following outline into a full blog post.
+
+Topic: {topic}
+Outline:
+{outline_block}
+
+Background snippets to draw on:
+{snippet_block}
+
+Return the full post body in Markdown.
+"""
+    return await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+
+
 if __name__ == "__main__":
     asyncio.run(test_generation())

--- a/src/cofounder_agent/services/internal_rag_source.py
+++ b/src/cofounder_agent/services/internal_rag_source.py
@@ -1,0 +1,124 @@
+"""Generate topic candidates from the internal embedded corpus.
+
+The Glad Labs writing pivot — instead of summarising external content,
+mine our own claude_sessions / brain_knowledge / audit / decision_log /
+git history / memory / posts for storyworthy events and turn each into
+a proposed topic + angle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+VALID_SOURCE_KINDS = (
+    "claude_session", "brain_knowledge", "audit_event",
+    "git_commit", "decision_log", "memory_file", "post_history",
+)
+
+
+@dataclass
+class InternalCandidate:
+    source_kind: str
+    primary_ref: str           # the source_table row id / commit sha / file path
+    distilled_topic: str
+    distilled_angle: str
+    supporting_refs: list[dict[str, Any]] = field(default_factory=list)
+    raw_snippet: str = ""
+
+
+class InternalRagSource:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def generate(
+        self,
+        *,
+        niche_id: UUID | str,
+        source_kinds: list[str],
+        per_kind_limit: int = 5,
+    ) -> list[InternalCandidate]:
+        bad = [s for s in source_kinds if s not in VALID_SOURCE_KINDS]
+        if bad:
+            raise ValueError(f"unknown source_kinds: {bad}")
+
+        results: list[InternalCandidate] = []
+        for kind in source_kinds:
+            snippets = await self._fetch_recent_snippets(kind, per_kind_limit)
+            for primary_ref, snippet, supporting in snippets:
+                topic, angle = await self._distill_topic_angle(
+                    [snippet] + [s["snippet"] for s in supporting],
+                )
+                results.append(InternalCandidate(
+                    source_kind=kind,
+                    primary_ref=primary_ref,
+                    distilled_topic=topic,
+                    distilled_angle=angle,
+                    supporting_refs=supporting,
+                    raw_snippet=snippet,
+                ))
+        return results
+
+    async def _fetch_recent_snippets(
+        self, source_kind: str, limit: int,
+    ) -> list[tuple[str, str, list[dict[str, Any]]]]:
+        """Pull the most-recent N entries for this kind from the embeddings table.
+
+        Returns list of (primary_ref, snippet, supporting_refs).
+        Mapping source_kind → embeddings.source_table:
+          claude_session → 'claude_sessions'
+          brain_knowledge → 'brain'
+          audit_event → 'audit'
+          git_commit → (TBD: needs git log query, not embeddings)
+          decision_log → 'memory' filtered to decision_log
+          memory_file → 'memory'
+          post_history → 'posts'
+        """
+        # Translate source_kind to the embeddings.source_table name
+        table_map = {
+            "claude_session": "claude_sessions",
+            "brain_knowledge": "brain",
+            "audit_event": "audit",
+            "decision_log": "memory",
+            "memory_file": "memory",
+            "post_history": "posts",
+        }
+        st = table_map.get(source_kind)
+        if st is None:
+            # git_commit not yet implemented — would query git log directly
+            return []
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT source_id, text_preview
+                  FROM embeddings
+                 WHERE source_table = $1
+                 ORDER BY created_at DESC
+                 LIMIT $2
+                """,
+                st, limit,
+            )
+        return [(str(r["source_id"]), r["text_preview"] or "", []) for r in rows]
+
+    async def _distill_topic_angle(self, snippets: list[str]) -> tuple[str, str]:
+        """Run a small LLM call to extract a proposed (topic, angle) from raw snippets."""
+        from services.topic_ranking import _ollama_chat_json
+        joined = "\n---\n".join(s[:600] for s in snippets if s)
+        prompt = f"""Read the snippets from an AI-operated content business's internal records.
+Extract a proposed blog post topic and the unique angle (the "why this matters / what we learned").
+
+Snippets:
+{joined}
+
+Return STRICT JSON: {{"topic": "<short title>", "angle": "<one-sentence framing>"}}.
+"""
+        raw = await _ollama_chat_json(prompt, model="glm-4.7-5090:latest")
+        import json
+        parsed = json.loads(raw)
+        return parsed.get("topic", "Untitled"), parsed.get("angle", "")

--- a/src/cofounder_agent/services/migrations/0113_create_niche_topic_discovery_tables.py
+++ b/src/cofounder_agent/services/migrations/0113_create_niche_topic_discovery_tables.py
@@ -1,0 +1,144 @@
+"""Migration 0113: niche-aware topic discovery tables.
+
+Adds the data layer for the RAG pivot + niche-aware topic discovery
+design (docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).
+
+Tables:
+- niches                       — first-class niche configuration
+- niche_goals                  — weighted goals per niche (TRAFFIC, EDUCATION, ...)
+- niche_sources                — per-niche source plugin toggles + weights
+- topic_batches                — operator-interaction unit
+- topic_candidates             — external (HN, dev.to, web_search) candidates
+- internal_topic_candidates    — RAG-derived candidates (different shape)
+- discovery_runs               — observability: when sweeps fire + what they produce
+
+All UUIDs default via gen_random_uuid (pgcrypto extension already loaded).
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niches (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                slug            TEXT UNIQUE NOT NULL,
+                name            TEXT NOT NULL,
+                active          BOOLEAN NOT NULL DEFAULT true,
+                target_audience_tags TEXT[] NOT NULL DEFAULT '{}',
+                writer_prompt_override TEXT,
+                writer_rag_mode TEXT NOT NULL DEFAULT 'TOPIC_ONLY'
+                    CHECK (writer_rag_mode IN ('TOPIC_ONLY','CITATION_BUDGET','STORY_SPINE','TWO_PASS')),
+                batch_size      INT NOT NULL DEFAULT 5 CHECK (batch_size BETWEEN 1 AND 20),
+                discovery_cadence_minute_floor INT NOT NULL DEFAULT 60 CHECK (discovery_cadence_minute_floor >= 1),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niche_goals (
+                niche_id   UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                goal_type  TEXT NOT NULL
+                    CHECK (goal_type IN ('TRAFFIC','EDUCATION','BRAND','AUTHORITY','REVENUE','COMMUNITY','NICHE_DEPTH')),
+                weight_pct INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+                PRIMARY KEY (niche_id, goal_type)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS niche_sources (
+                niche_id    UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_name TEXT NOT NULL,
+                enabled     BOOLEAN NOT NULL DEFAULT true,
+                weight_pct  INT NOT NULL CHECK (weight_pct BETWEEN 0 AND 100),
+                PRIMARY KEY (niche_id, source_name)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS topic_batches (
+                id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                niche_id     UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                status       TEXT NOT NULL CHECK (status IN ('open','resolved','expired')),
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                expires_at   TIMESTAMPTZ NOT NULL,
+                resolved_at  TIMESTAMPTZ,
+                picked_candidate_id UUID,
+                picked_candidate_kind TEXT CHECK (picked_candidate_kind IN ('external','internal') OR picked_candidate_kind IS NULL)
+            )
+        """)
+        await conn.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_one_open_batch_per_niche
+                ON topic_batches (niche_id) WHERE status = 'open'
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS topic_candidates (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_name     TEXT NOT NULL,
+                source_ref      TEXT NOT NULL,
+                title           TEXT NOT NULL,
+                summary         TEXT,
+                score           NUMERIC NOT NULL,
+                score_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+                rank_in_batch   INT NOT NULL,
+                operator_rank   INT,
+                operator_edited_topic TEXT,
+                operator_edited_angle TEXT,
+                decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+                carried_from_batch_id UUID REFERENCES topic_batches(id),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE (batch_id, source_name, source_ref)
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS internal_topic_candidates (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                batch_id        UUID NOT NULL REFERENCES topic_batches(id) ON DELETE CASCADE,
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                source_kind     TEXT NOT NULL
+                    CHECK (source_kind IN ('claude_session','brain_knowledge','audit_event','git_commit','decision_log','memory_file','post_history')),
+                primary_ref     TEXT NOT NULL,
+                supporting_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+                distilled_topic TEXT NOT NULL,
+                distilled_angle TEXT NOT NULL,
+                score           NUMERIC NOT NULL,
+                score_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+                rank_in_batch   INT NOT NULL,
+                operator_rank   INT,
+                operator_edited_topic TEXT,
+                operator_edited_angle TEXT,
+                decay_factor    NUMERIC NOT NULL DEFAULT 1.0,
+                carried_from_batch_id UUID REFERENCES topic_batches(id),
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS discovery_runs (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                niche_id        UUID NOT NULL REFERENCES niches(id) ON DELETE CASCADE,
+                started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                finished_at     TIMESTAMPTZ,
+                candidates_generated      INT,
+                candidates_carried_forward INT,
+                batch_id        UUID REFERENCES topic_batches(id),
+                error           TEXT
+            )
+        """)
+        # Helpful indexes
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_topic_candidates_batch ON topic_candidates(batch_id)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_internal_topic_candidates_batch ON internal_topic_candidates(batch_id)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS ix_discovery_runs_niche_started ON discovery_runs(niche_id, started_at DESC)")
+        logger.info("Created niche topic-discovery tables (0113)")
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        for tbl in (
+            "discovery_runs", "internal_topic_candidates", "topic_candidates",
+            "topic_batches", "niche_sources", "niche_goals", "niches",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {tbl} CASCADE")
+        logger.info("Dropped niche topic-discovery tables (0113 down)")

--- a/src/cofounder_agent/services/migrations/0114_extend_content_tasks_for_niches.py
+++ b/src/cofounder_agent/services/migrations/0114_extend_content_tasks_for_niches.py
@@ -1,0 +1,47 @@
+"""Migration 0114: extend content_tasks for niche-aware pipeline handoff.
+
+Adds three columns the new TopicBatchService.handoff path writes:
+- niche_slug         (which niche the task belongs to)
+- writer_rag_mode    (the writer mode the writer dispatcher reads)
+- topic_batch_id     (provenance pointer to the batch the topic came from)
+
+All nullable for backward compat — existing tasks predate niches and stay valid.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 8)
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            ALTER TABLE content_tasks
+              ADD COLUMN IF NOT EXISTS niche_slug TEXT,
+              ADD COLUMN IF NOT EXISTS writer_rag_mode TEXT
+                CHECK (writer_rag_mode IN ('TOPIC_ONLY','CITATION_BUDGET','STORY_SPINE','TWO_PASS') OR writer_rag_mode IS NULL),
+              ADD COLUMN IF NOT EXISTS topic_batch_id UUID REFERENCES topic_batches(id)
+        """)
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS ix_content_tasks_niche ON content_tasks(niche_slug) WHERE niche_slug IS NOT NULL"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS ix_content_tasks_batch ON content_tasks(topic_batch_id) WHERE topic_batch_id IS NOT NULL"
+        )
+        logger.info("Extended content_tasks with niche columns (0114)")
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("DROP INDEX IF EXISTS ix_content_tasks_batch")
+        await conn.execute("DROP INDEX IF EXISTS ix_content_tasks_niche")
+        await conn.execute("""
+            ALTER TABLE content_tasks
+              DROP COLUMN IF EXISTS topic_batch_id,
+              DROP COLUMN IF EXISTS writer_rag_mode,
+              DROP COLUMN IF EXISTS niche_slug
+        """)
+        logger.info("Dropped content_tasks niche columns (0114 down)")

--- a/src/cofounder_agent/services/migrations/0115_seed_glad_labs_niche.py
+++ b/src/cofounder_agent/services/migrations/0115_seed_glad_labs_niche.py
@@ -1,0 +1,68 @@
+"""Migration 0115: seed Glad Labs as the first configured niche.
+
+Uses TWO_PASS writer mode (per spec — Glad Labs is the primary-source niche
+where we lean hardest on internal RAG context). Goals are the operator's
+opening guesses; tune later via the CLI.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 17)
+"""
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        existing = await conn.fetchval("SELECT id FROM niches WHERE slug = 'glad-labs'")
+        if existing is not None:
+            logger.info("Glad Labs niche already exists (id=%s) — skipping seed", existing)
+            return
+
+        niche_id = await conn.fetchval(
+            """
+            INSERT INTO niches (slug, name, target_audience_tags,
+                                writer_rag_mode, batch_size,
+                                discovery_cadence_minute_floor)
+            VALUES ('glad-labs', 'Glad Labs',
+                    ARRAY['indie-devs','ai-curious','prospects','future-matt'],
+                    'TWO_PASS', 5, 60)
+            RETURNING id
+            """,
+        )
+
+        # Goals (sum to 100)
+        goals = [
+            ("AUTHORITY", 35),  # show what we actually know
+            ("EDUCATION", 25),  # teach the reader
+            ("BRAND",     20),  # reinforce the Glad Labs voice
+            ("TRAFFIC",   15),  # not nothing, but not the driver
+            ("REVENUE",    5),  # eventually
+        ]
+        for goal_type, weight in goals:
+            await conn.execute(
+                "INSERT INTO niche_goals (niche_id, goal_type, weight_pct) VALUES ($1, $2, $3)",
+                niche_id, goal_type, weight,
+            )
+
+        # Sources — internal_rag is the lead, plus the existing external feeds
+        sources = [
+            ("internal_rag", True, 50),
+            ("hackernews",   True, 20),
+            ("devto",        True, 15),
+            ("web_search",   True, 10),
+            ("knowledge",    True,  5),
+        ]
+        for name, enabled, weight in sources:
+            await conn.execute(
+                "INSERT INTO niche_sources (niche_id, source_name, enabled, weight_pct) VALUES ($1, $2, $3, $4)",
+                niche_id, name, enabled, weight,
+            )
+        logger.info("Seeded Glad Labs niche (id=%s)", niche_id)
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM niches WHERE slug = 'glad-labs'")
+        logger.info("Removed Glad Labs niche seed (0115 down)")

--- a/src/cofounder_agent/services/niche_service.py
+++ b/src/cofounder_agent/services/niche_service.py
@@ -1,0 +1,151 @@
+"""CRUD service for niches + their goals + their source configs.
+
+Niches are the first-class configuration unit for the topic-discovery + RAG
+pivot (see docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).
+Glad Labs is the first niche; future operators add their own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+_VALID_GOAL_TYPES = frozenset({
+    "TRAFFIC", "EDUCATION", "BRAND", "AUTHORITY",
+    "REVENUE", "COMMUNITY", "NICHE_DEPTH",
+})
+
+_VALID_RAG_MODES = frozenset({
+    "TOPIC_ONLY", "CITATION_BUDGET", "STORY_SPINE", "TWO_PASS",
+})
+
+
+@dataclass(frozen=True)
+class Niche:
+    id: UUID
+    slug: str
+    name: str
+    active: bool
+    target_audience_tags: list[str]
+    writer_prompt_override: str | None
+    writer_rag_mode: str
+    batch_size: int
+    discovery_cadence_minute_floor: int
+
+
+@dataclass(frozen=True)
+class NicheGoal:
+    goal_type: str
+    weight_pct: int
+
+
+@dataclass(frozen=True)
+class NicheSource:
+    source_name: str
+    enabled: bool
+    weight_pct: int
+
+
+class NicheService:
+    def __init__(self, pool):
+        self._pool = pool
+
+    async def create(
+        self, *, slug: str, name: str,
+        target_audience_tags: list[str] | None = None,
+        writer_prompt_override: str | None = None,
+        writer_rag_mode: str = "TOPIC_ONLY",
+        batch_size: int = 5,
+        discovery_cadence_minute_floor: int = 60,
+    ) -> Niche:
+        if writer_rag_mode not in _VALID_RAG_MODES:
+            raise ValueError(f"invalid writer_rag_mode: {writer_rag_mode!r}")
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO niches (slug, name, target_audience_tags,
+                                    writer_prompt_override, writer_rag_mode,
+                                    batch_size, discovery_cadence_minute_floor)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                RETURNING *
+                """,
+                slug, name, list(target_audience_tags or []),
+                writer_prompt_override, writer_rag_mode,
+                batch_size, discovery_cadence_minute_floor,
+            )
+        return _row_to_niche(row)
+
+    async def get_by_slug(self, slug: str) -> Niche | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM niches WHERE slug = $1", slug)
+        return _row_to_niche(row) if row else None
+
+    async def get_by_id(self, niche_id: UUID) -> Niche | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM niches WHERE id = $1", niche_id)
+        return _row_to_niche(row) if row else None
+
+    async def list_active(self) -> list[Niche]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM niches WHERE active ORDER BY slug")
+        return [_row_to_niche(r) for r in rows]
+
+    async def set_goals(self, niche_id: UUID, goals: list[NicheGoal]) -> None:
+        bad = [g.goal_type for g in goals if g.goal_type not in _VALID_GOAL_TYPES]
+        if bad:
+            raise ValueError(f"invalid goal_type(s): {bad}")
+        total = sum(g.weight_pct for g in goals)
+        if not 99 <= total <= 101:
+            raise ValueError(f"weights must sum to ~100, got {total}")
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("DELETE FROM niche_goals WHERE niche_id = $1", niche_id)
+                for g in goals:
+                    await conn.execute(
+                        "INSERT INTO niche_goals (niche_id, goal_type, weight_pct) VALUES ($1,$2,$3)",
+                        niche_id, g.goal_type, g.weight_pct,
+                    )
+
+    async def get_goals(self, niche_id: UUID) -> list[NicheGoal]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT goal_type, weight_pct FROM niche_goals WHERE niche_id = $1 ORDER BY weight_pct DESC",
+                niche_id,
+            )
+        return [NicheGoal(goal_type=r["goal_type"], weight_pct=r["weight_pct"]) for r in rows]
+
+    async def set_sources(self, niche_id: UUID, sources: list[NicheSource]) -> None:
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("DELETE FROM niche_sources WHERE niche_id = $1", niche_id)
+                for s in sources:
+                    await conn.execute(
+                        "INSERT INTO niche_sources (niche_id, source_name, enabled, weight_pct) VALUES ($1,$2,$3,$4)",
+                        niche_id, s.source_name, s.enabled, s.weight_pct,
+                    )
+
+    async def get_sources(self, niche_id: UUID) -> list[NicheSource]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT source_name, enabled, weight_pct FROM niche_sources "
+                "WHERE niche_id = $1 ORDER BY weight_pct DESC",
+                niche_id,
+            )
+        return [NicheSource(**dict(r)) for r in rows]
+
+
+def _row_to_niche(row: Any) -> Niche:
+    return Niche(
+        id=row["id"], slug=row["slug"], name=row["name"], active=row["active"],
+        target_audience_tags=list(row["target_audience_tags"] or []),
+        writer_prompt_override=row["writer_prompt_override"],
+        writer_rag_mode=row["writer_rag_mode"],
+        batch_size=row["batch_size"],
+        discovery_cadence_minute_floor=row["discovery_cadence_minute_floor"],
+    )

--- a/src/cofounder_agent/services/research_service.py
+++ b/src/cofounder_agent/services/research_service.py
@@ -287,3 +287,48 @@ class ResearchService:
         except Exception as e:
             logger.debug("[RESEARCH] Web search failed: %s", e)
             return []
+
+
+# ---------------------------------------------------------------------------
+# Module-level shim for the TWO_PASS writer mode (Task 14)
+# ---------------------------------------------------------------------------
+
+
+async def research_topic(query: str, max_sources: int = 2) -> str:
+    """Shim for the TWO_PASS writer mode's external fact-augmentation step.
+
+    Wraps ``ResearchService.build_context`` so the writer can ask for a
+    single fact lookup without instantiating the full service with a DB
+    pool. Constructed with ``pool=None`` — that disables the
+    ``_find_internal_links`` step (returns []) but keeps the known-references
+    lookup and the free DuckDuckGo web search, which are the two sources
+    that matter for filling [EXTERNAL_NEEDED] markers.
+
+    ``max_sources`` is currently advisory: the underlying ``build_context``
+    method caps internally (5 web results, 8 references). Plumbing a true
+    cap requires refactoring ``ResearchService.build_context`` itself,
+    which is out of scope for Task 14.
+
+    Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+    Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 14)
+    """
+    try:
+        svc = ResearchService(pool=None)
+        ctx = await svc.build_context(query)
+        if not ctx:
+            logger.info(
+                "[RESEARCH] research_topic('%s') produced no context — "
+                "returning empty stub", query[:60],
+            )
+            return ""
+        return ctx
+    except Exception as e:
+        # Don't crash the TWO_PASS revise loop if research is unavailable
+        # (e.g. DuckDuckGo rate-limited, no network). Return a clearly-marked
+        # stub so the LLM can still produce a coherent revision and the
+        # downstream validator can flag the missing citation.
+        logger.warning(
+            "[RESEARCH] research_topic('%s') failed: %s — returning stub",
+            query[:60], e,
+        )
+        return f"[research stub for: {query}]"

--- a/src/cofounder_agent/services/stages/generate_content.py
+++ b/src/cofounder_agent/services/stages/generate_content.py
@@ -122,23 +122,44 @@ class GenerateContentStage:
         # same sources the writer consulted.
         context["research_context"] = research_context
 
-        # Generate content (GPU-locked to ollama mode).
-        from services.gpu_scheduler import gpu
-        async with gpu.lock(
-            "ollama", model=preferred_model,
-            task_id=task_id, phase="generate_content",
-        ):
-            content_text, model_used, metrics = await content_generator.generate_blog_post(
+        # Task 14 (RAG pivot): if the task carries a writer_rag_mode set by
+        # the niche topic-discovery handoff, route to the new writer-mode
+        # dispatcher instead of the legacy generator. The legacy path stays
+        # intact for tasks with no writer_rag_mode (column is nullable per
+        # migration 0114, so pre-niche tasks remain backward-compatible).
+        writer_rag_mode = await self._read_writer_rag_mode(database_service, task_id)
+        if writer_rag_mode:
+            logger.info(
+                "STAGE 2: writer_rag_mode=%s — dispatching to writer_rag_modes",
+                writer_rag_mode,
+            )
+            content_text, model_used, metrics = await self._generate_via_writer_mode(
+                writer_rag_mode=writer_rag_mode,
                 topic=topic,
                 style=style,
                 tone=tone,
-                target_length=target_length,
                 tags=tags,
-                preferred_model=preferred_model,
-                preferred_provider=preferred_provider,
-                writing_style_context=writing_style_context,
-                research_context=research_context,
+                database_service=database_service,
+                task_id=task_id,
             )
+        else:
+            # Generate content (GPU-locked to ollama mode).
+            from services.gpu_scheduler import gpu
+            async with gpu.lock(
+                "ollama", model=preferred_model,
+                task_id=task_id, phase="generate_content",
+            ):
+                content_text, model_used, metrics = await content_generator.generate_blog_post(
+                    topic=topic,
+                    style=style,
+                    tone=tone,
+                    target_length=target_length,
+                    tags=tags,
+                    preferred_model=preferred_model,
+                    preferred_provider=preferred_provider,
+                    writing_style_context=writing_style_context,
+                    research_context=research_context,
+                )
 
         if not content_text:
             logger.error("Content generation returned None or empty")
@@ -387,6 +408,105 @@ class GenerateContentStage:
             logger.warning("RAG context skipped (non-fatal): %s", e)
 
         return research_context
+
+    async def _read_writer_rag_mode(
+        self, database_service: Any, task_id: str,
+    ) -> str | None:
+        """Return the task's writer_rag_mode if set, else None.
+
+        Task 14: niches set this column when handing tasks off via
+        TopicBatchService; legacy/manual tasks leave it NULL and stay on the
+        legacy generator path.
+        """
+        try:
+            task_row = await database_service.get_task(task_id)
+            if not task_row:
+                return None
+            mode = task_row.get("writer_rag_mode")
+            if not mode:
+                return None
+            return str(mode).strip().upper() or None
+        except Exception as e:
+            logger.warning(
+                "Failed to read writer_rag_mode for task %s: %s — falling back to legacy path",
+                task_id, e,
+            )
+            return None
+
+    async def _generate_via_writer_mode(
+        self,
+        *,
+        writer_rag_mode: str,
+        topic: str,
+        style: str,
+        tone: str,
+        tags: list[str],
+        database_service: Any,
+        task_id: str,
+    ) -> tuple[str, str, dict[str, Any]]:
+        """Run dispatch_writer_mode and shape the result into the
+        (content_text, model_used, metrics) tuple the rest of this stage
+        already expects.
+
+        The dispatcher returns a richer dict ({draft, snippets_used, mode,
+        ...}); we surface mode-specific extras inside ``metrics`` so the
+        downstream QA / persistence stages can see them but the main flow
+        stays unchanged.
+        """
+        from services.writer_rag_modes import dispatch_writer_mode
+
+        # The writer modes use "angle" rather than separate style/tone/tags;
+        # collapse the available descriptors into a single angle string.
+        angle_parts = [p for p in (style, tone) if p]
+        if tags:
+            angle_parts.append("tags: " + ", ".join(tags))
+        angle = " | ".join(angle_parts) or "general"
+
+        pool = getattr(database_service, "pool", None)
+        if pool is None:
+            raise ValueError(
+                "writer_rag_mode dispatch requires database_service.pool but it is None"
+            )
+
+        # niche_id is not strictly needed by the modes themselves — the modes
+        # query the global embeddings table by topic+angle similarity. If a
+        # downstream mode wants to scope to a niche it can look the niche_id
+        # up via the task row's niche_slug.
+        from services.gpu_scheduler import gpu
+        async with gpu.lock(
+            "ollama", model="glm-4.7-5090:latest",
+            task_id=task_id, phase="generate_content",
+        ):
+            result = await dispatch_writer_mode(
+                mode=writer_rag_mode,
+                topic=topic,
+                angle=angle,
+                niche_id=None,
+                pool=pool,
+            )
+
+        draft = result.get("draft") or ""
+        # The writer-mode helpers all call _ollama_chat_json with this model.
+        # If a future mode picks a different model it should put it on the
+        # result dict so we can surface the real value.
+        model_used = result.get("model_used") or "glm-4.7-5090:latest"
+        metrics: dict[str, Any] = {
+            "writer_rag_mode": writer_rag_mode,
+            "snippets_used_count": len(result.get("snippets_used") or []),
+            "models_used_by_phase": {"generate_content": model_used},
+            "model_selection_log": {
+                "generate_content": {
+                    "preferred": model_used,
+                    "actual": model_used,
+                    "source": "writer_rag_mode_dispatch",
+                },
+            },
+        }
+        # TWO_PASS-specific extras (LangGraph state machine output).
+        for k in ("external_lookups", "revision_loops", "loop_capped", "spine"):
+            if k in result:
+                metrics[k] = result[k]
+        return draft, model_used, metrics
 
     async def _fetch_existing_titles(self, database_service: Any) -> str:
         """Return newline-separated recent published titles for avoidance prompt."""

--- a/src/cofounder_agent/services/topic_batch_service.py
+++ b/src/cofounder_agent/services/topic_batch_service.py
@@ -1,0 +1,428 @@
+"""Topic batch orchestrator — replaces topic_proposal_service.
+
+Per-niche flow:
+  1. discover candidates (external source plugins + InternalRagSource) per
+     niche_sources weights → pool of ~20
+  2. carry-forward leftover candidates from prior batch with decay
+  3. embedding pre-rank against goal vectors → top 10
+  4. LLM final-score on the top 10 → final batch_size winners
+  5. write topic_batch + topic_candidates / internal_topic_candidates rows
+  6. open the topic_decision approval gate
+  7. record discovery_run
+
+See spec §"Flow" + §"Discovery sweep" in
+docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md.
+
+Implementation note — lazy imports
+==================================
+Both ``embed_text`` and ``llm_final_score`` are imported *inside* the
+methods that use them rather than at module top-level. This keeps the
+test seam intact: ``monkeypatch.setattr("services.topic_ranking.embed_text", ...)``
+needs to patch the source module before it's bound into our namespace,
+otherwise the test would have to patch
+``services.topic_batch_service.embed_text`` instead. Lazy imports give
+test authors the cleaner patch path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+from services.niche_service import Niche, NicheService
+from services.topic_ranking import (
+    ScoredCandidate,
+    apply_decay,
+    goal_vector_for,
+    weighted_cosine_score,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class BatchSnapshot:
+    id: UUID
+    niche_id: UUID
+    status: str
+    candidate_count: int
+    expires_at: datetime
+
+
+class TopicBatchService:
+    def __init__(self, pool):
+        self._pool = pool
+        self._niche_svc = NicheService(pool)
+
+    async def run_sweep(self, *, niche_id: UUID) -> BatchSnapshot | None:
+        niche = await self._niche_svc.get_by_id(niche_id)
+        if niche is None:
+            raise ValueError(f"unknown niche_id: {niche_id}")
+        if not await self._floor_elapsed(niche):
+            logger.info(
+                "Sweep skipped — discovery cadence floor not elapsed for niche %s",
+                niche.slug,
+            )
+            return None
+        if await self._open_batch_exists(niche.id):
+            logger.info(
+                "Sweep skipped — open batch already exists for niche %s",
+                niche.slug,
+            )
+            return None
+
+        async with self._pool.acquire() as conn:
+            run = await conn.fetchrow(
+                "INSERT INTO discovery_runs (niche_id) VALUES ($1) RETURNING *",
+                niche.id,
+            )
+        run_id = run["id"]
+
+        try:
+            external = await self._discover_external(niche)
+            internal = await self._discover_internal(niche)
+            carried = await self._load_carry_forward(niche.id)
+
+            pool_external, pool_internal = await self._embed_and_pre_rank(
+                niche,
+                external + carried["external"],
+                internal + carried["internal"],
+            )
+
+            top10 = pool_external[:5] + pool_internal[:5]
+
+            # Lazy import so tests can patch services.topic_ranking.llm_final_score.
+            from services.topic_ranking import llm_final_score
+
+            goals = await self._niche_svc.get_goals(niche.id)
+            scored = await llm_final_score(top10, goals)
+
+            ranked = sorted(
+                scored.values(), key=lambda c: -(c.llm_score or 0)
+            )[: niche.batch_size]
+
+            batch = await self._write_batch(
+                niche, ranked, pool_external, pool_internal,
+            )
+
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE discovery_runs SET finished_at = NOW(), batch_id = $1, "
+                    "candidates_generated = $2, candidates_carried_forward = $3 "
+                    "WHERE id = $4",
+                    batch.id,
+                    len(external) + len(internal),
+                    len(carried["external"]) + len(carried["internal"]),
+                    run_id,
+                )
+
+            await self._open_topic_decision_gate(batch)
+            return batch
+        except Exception as exc:
+            async with self._pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE discovery_runs SET finished_at = NOW(), error = $1 WHERE id = $2",
+                    str(exc),
+                    run_id,
+                )
+            raise
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _floor_elapsed(self, niche: Niche) -> bool:
+        """True if enough time has passed since the last sweep for this niche.
+
+        Compares against ``MAX(started_at)`` — even an in-flight or errored
+        run counts toward the floor so we don't hammer external sources
+        when something's wedged. Excludes the current run because this
+        check runs *before* the discovery_runs INSERT.
+        """
+        async with self._pool.acquire() as conn:
+            last = await conn.fetchval(
+                "SELECT MAX(started_at) FROM discovery_runs WHERE niche_id = $1",
+                niche.id,
+            )
+        if last is None:
+            return True
+        floor = timedelta(minutes=niche.discovery_cadence_minute_floor)
+        return (datetime.now(timezone.utc) - last) >= floor
+
+    async def _open_batch_exists(self, niche_id: UUID) -> bool:
+        async with self._pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM topic_batches "
+                "WHERE niche_id = $1 AND status = 'open'",
+                niche_id,
+            )
+        return (count or 0) > 0
+
+    async def _discover_external(self, niche: Niche) -> list[dict[str, Any]]:
+        """Call existing topic_discovery wiring for non-internal sources.
+
+        TODO(Task 6 follow-up): wire to ``services.topic_discovery.TopicDiscovery``
+        once the per-niche source plugin filter is exposed. Today we log
+        a warning (so misconfiguration surfaces) and return [].
+        """
+        sources = await self._niche_svc.get_sources(niche.id)
+        external_sources = [
+            s for s in sources if s.enabled and s.source_name != "internal_rag"
+        ]
+        if external_sources:
+            logger.warning(
+                "Niche %s has %d external source(s) configured but topic_discovery "
+                "wiring is not yet implemented in TopicBatchService — returning [] "
+                "(TODO follow-up task)",
+                niche.slug,
+                len(external_sources),
+            )
+        return []
+
+    async def _discover_internal(self, niche: Niche) -> list[dict[str, Any]]:
+        sources = await self._niche_svc.get_sources(niche.id)
+        if not any(
+            s.source_name == "internal_rag" and s.enabled for s in sources
+        ):
+            return []
+        from services.internal_rag_source import InternalRagSource
+
+        rag = InternalRagSource(self._pool)
+        # Per spec: per-kind limit 4, all 6 valid kinds except git_commit
+        # (which still needs git-log plumbing).
+        kinds = [
+            "claude_session",
+            "brain_knowledge",
+            "audit_event",
+            "decision_log",
+            "memory_file",
+            "post_history",
+        ]
+        cands = await rag.generate(
+            niche_id=niche.id, source_kinds=kinds, per_kind_limit=4,
+        )
+        return [{"kind": "internal", "data": c} for c in cands]
+
+    async def _load_carry_forward(self, niche_id: UUID) -> dict[str, list]:
+        """Pull unpicked candidates from the most recent resolved batch and
+        return them with ``decay_factor`` pre-multiplied by 0.7.
+
+        The 0.7 decay multiplier on each carry-forward implements the spec's
+        "older candidates lose weight" — by the third batch a candidate has
+        decayed to 0.7^3 ≈ 0.343 of its original score.
+        """
+        async with self._pool.acquire() as conn:
+            ext = await conn.fetch(
+                """
+                SELECT * FROM topic_candidates
+                 WHERE niche_id = $1 AND operator_rank IS NULL
+                   AND batch_id IN (
+                       SELECT id FROM topic_batches
+                        WHERE niche_id = $1 AND status = 'resolved'
+                     ORDER BY resolved_at DESC LIMIT 1
+                   )
+                """,
+                niche_id,
+            )
+            int_ = await conn.fetch(
+                """
+                SELECT * FROM internal_topic_candidates
+                 WHERE niche_id = $1 AND operator_rank IS NULL
+                   AND batch_id IN (
+                       SELECT id FROM topic_batches
+                        WHERE niche_id = $1 AND status = 'resolved'
+                     ORDER BY resolved_at DESC LIMIT 1
+                   )
+                """,
+                niche_id,
+            )
+        return {
+            "external": [
+                {"row": dict(r), "decay_factor": float(r["decay_factor"]) * 0.7}
+                for r in ext
+            ],
+            "internal": [
+                {"row": dict(r), "decay_factor": float(r["decay_factor"]) * 0.7}
+                for r in int_
+            ],
+        }
+
+    async def _embed_and_pre_rank(
+        self,
+        niche: Niche,
+        external: list,
+        internal: list,
+    ) -> tuple[list[ScoredCandidate], list[ScoredCandidate]]:
+        """Compute embedding + weighted cosine score per candidate.
+
+        Returns (top external, top internal) — top 5 each, sorted by score
+        descending.
+
+        ``embed_text`` is imported lazily so
+        ``monkeypatch.setattr("services.topic_ranking.embed_text", ...)``
+        works without reaching into this module's namespace.
+        """
+        from services.topic_ranking import embed_text
+
+        goals = await self._niche_svc.get_goals(niche.id)
+        goal_vecs = {
+            g.goal_type: await goal_vector_for(g.goal_type) for g in goals
+        }
+
+        async def score_one(text: str, decay: float) -> tuple[float, dict[str, float]]:
+            vec = await embed_text(text)
+            raw, breakdown = weighted_cosine_score(vec, goal_vecs, goals)
+            return apply_decay(score=raw, decay_factor=decay), breakdown
+
+        ext_scored: list[ScoredCandidate] = []
+        for item in external:
+            # External candidates are dicts (carry-forward rows or plugin
+            # output). Carry-forward rows have a "row" key; fresh discovery
+            # output is the dict itself.
+            row = item.get("row") if isinstance(item, dict) and "row" in item else item
+            text = (row.get("title") or "") + " " + (row.get("summary") or "")
+            decay = item.get("decay_factor", 1.0) if isinstance(item, dict) else 1.0
+            score, breakdown = await score_one(text, decay)
+            ext_scored.append(
+                ScoredCandidate(
+                    id=str(row.get("id") or row.get("source_ref") or text[:40]),
+                    title=row.get("title") or "Untitled",
+                    summary=row.get("summary"),
+                    embedding_score=score,
+                    score_breakdown=breakdown,
+                )
+            )
+
+        int_scored: list[ScoredCandidate] = []
+        for item in internal:
+            data = item["data"] if isinstance(item, dict) and "data" in item else item.get("row", item)
+            decay = item.get("decay_factor", 1.0) if isinstance(item, dict) else 1.0
+
+            # ``data`` is either an InternalCandidate dataclass (fresh) or a
+            # row dict (carry-forward). Reach in via getattr-with-fallback
+            # so both shapes work.
+            def _field(name: str, default: str = "") -> str:
+                if hasattr(data, name):
+                    return getattr(data, name) or default
+                if isinstance(data, dict):
+                    return data.get(name) or default
+                return default
+
+            topic = _field("distilled_topic", "")
+            angle = _field("distilled_angle", "")
+            text = (topic + " " + angle).strip()
+            score, breakdown = await score_one(text, decay)
+
+            primary_ref = _field("primary_ref", text[:40])
+            int_scored.append(
+                ScoredCandidate(
+                    id=str(primary_ref or text[:40]),
+                    title=topic or "Untitled",
+                    summary=angle or None,
+                    embedding_score=score,
+                    score_breakdown=breakdown,
+                )
+            )
+
+        ext_scored.sort(key=lambda c: -c.embedding_score)
+        int_scored.sort(key=lambda c: -c.embedding_score)
+        return ext_scored[:5], int_scored[:5]
+
+    async def _write_batch(
+        self,
+        niche: Niche,
+        ranked: list[ScoredCandidate],
+        all_external: list,
+        all_internal: list,
+    ) -> BatchSnapshot:
+        """Create the topic_batches row + per-candidate rows in the
+        appropriate table (external vs internal).
+
+        Determines the destination table by checking which pre-rank pool
+        the candidate's id appears in. The two pools are disjoint by
+        construction (external candidates carry source_ref-derived ids;
+        internal candidates carry primary_ref-derived ids).
+
+        ``all_external`` and ``all_internal`` are
+        ``list[ScoredCandidate]`` — the embed-pre-rank output. We just
+        need their ids to route each ranked candidate to the right table.
+        """
+        internal_ids: set[str] = {str(sc.id) for sc in all_internal}
+
+        expires = datetime.now(timezone.utc) + timedelta(days=7)
+        rank_in_batch = 0
+
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                batch_row = await conn.fetchrow(
+                    "INSERT INTO topic_batches (niche_id, status, expires_at) "
+                    "VALUES ($1, 'open', $2) RETURNING *",
+                    niche.id,
+                    expires,
+                )
+                for c in ranked:
+                    rank_in_batch += 1
+                    is_internal = c.id in internal_ids
+                    if is_internal:
+                        await conn.execute(
+                            """
+                            INSERT INTO internal_topic_candidates
+                              (batch_id, niche_id, source_kind, primary_ref,
+                               supporting_refs, distilled_topic, distilled_angle,
+                               score, score_breakdown, rank_in_batch, decay_factor)
+                            VALUES ($1, $2, $3, $4, '[]'::jsonb, $5, $6, $7, $8::jsonb, $9, $10)
+                            """,
+                            batch_row["id"],
+                            niche.id,
+                            "claude_session",
+                            c.id,
+                            c.title,
+                            c.summary or "",
+                            c.llm_score or 0,
+                            _json(c.score_breakdown or {}),
+                            rank_in_batch,
+                            1.0,
+                        )
+                    else:
+                        await conn.execute(
+                            """
+                            INSERT INTO topic_candidates
+                              (batch_id, niche_id, source_name, source_ref, title, summary,
+                               score, score_breakdown, rank_in_batch, decay_factor)
+                            VALUES ($1, $2, 'external', $3, $4, $5, $6, $7::jsonb, $8, $9)
+                            """,
+                            batch_row["id"],
+                            niche.id,
+                            c.id,
+                            c.title,
+                            c.summary,
+                            c.llm_score or 0,
+                            _json(c.score_breakdown or {}),
+                            rank_in_batch,
+                            1.0,
+                        )
+
+        return BatchSnapshot(
+            id=batch_row["id"],
+            niche_id=batch_row["niche_id"],
+            status=batch_row["status"],
+            candidate_count=rank_in_batch,
+            expires_at=batch_row["expires_at"],
+        )
+
+    async def _open_topic_decision_gate(self, batch: BatchSnapshot) -> None:
+        """Open the operator approval gate for this new batch.
+
+        TODO(Task 6 follow-up): wire to ``services.approval_service`` once
+        the topic_decision gate API stabilises. Today this is a structured
+        log line so observability picks it up.
+        """
+        logger.info("Opened topic_decision gate for batch %s", batch.id)
+
+
+def _json(obj: Any) -> str:
+    return json.dumps(obj, default=str)

--- a/src/cofounder_agent/services/topic_batch_service.py
+++ b/src/cofounder_agent/services/topic_batch_service.py
@@ -53,6 +53,42 @@ class BatchSnapshot:
     expires_at: datetime
 
 
+@dataclass
+class CandidateView:
+    """Unified view of a candidate row across the external/internal
+    candidate tables — used by ``show_batch`` so the operator sees one
+    flat ranked list regardless of source table.
+
+    ``effective_score = score * decay_factor`` is precomputed so callers
+    don't have to repeat the multiply.
+    """
+
+    id: str
+    kind: str  # 'external' | 'internal'
+    title: str
+    summary: str | None
+    score: float
+    decay_factor: float
+    effective_score: float
+    rank_in_batch: int
+    operator_rank: int | None
+    operator_edited_topic: str | None
+    operator_edited_angle: str | None
+    score_breakdown: dict[str, float]
+
+
+@dataclass
+class BatchView:
+    """Operator-facing snapshot of a batch + every candidate, sorted by
+    ``effective_score`` desc."""
+
+    id: UUID
+    niche_id: UUID
+    status: str
+    picked_candidate_id: UUID | None
+    candidates: list[CandidateView]
+
+
 class TopicBatchService:
     def __init__(self, pool):
         self._pool = pool
@@ -424,6 +460,249 @@ class TopicBatchService:
         """
         logger.info("Opened topic_decision gate for batch %s", batch.id)
 
+    # ------------------------------------------------------------------
+    # Operator interactions (Task 7)
+    # ------------------------------------------------------------------
+
+    async def show_batch(self, *, batch_id: UUID) -> BatchView:
+        """Return a unified, ranked view of the batch + all candidates.
+
+        Merges rows from ``topic_candidates`` and
+        ``internal_topic_candidates`` so the operator UI doesn't have to
+        know which table a candidate lives in. Sorted by
+        ``effective_score`` (= score × decay_factor) desc so freshly
+        scored picks float to the top and decayed carry-forwards drift
+        down naturally.
+        """
+        async with self._pool.acquire() as conn:
+            batch = await conn.fetchrow(
+                "SELECT * FROM topic_batches WHERE id = $1", batch_id,
+            )
+            if batch is None:
+                raise ValueError(f"unknown batch_id: {batch_id}")
+            ext_rows = await conn.fetch(
+                "SELECT * FROM topic_candidates WHERE batch_id = $1", batch_id,
+            )
+            int_rows = await conn.fetch(
+                "SELECT * FROM internal_topic_candidates WHERE batch_id = $1",
+                batch_id,
+            )
+
+        cands: list[CandidateView] = []
+        for r in ext_rows:
+            score = float(r["score"])
+            df = float(r["decay_factor"])
+            cands.append(
+                CandidateView(
+                    id=str(r["id"]),
+                    kind="external",
+                    title=r["title"],
+                    summary=r["summary"],
+                    score=score,
+                    decay_factor=df,
+                    effective_score=score * df,
+                    rank_in_batch=r["rank_in_batch"],
+                    operator_rank=r["operator_rank"],
+                    operator_edited_topic=r["operator_edited_topic"],
+                    operator_edited_angle=r["operator_edited_angle"],
+                    score_breakdown=_loads(r["score_breakdown"]) or {},
+                )
+            )
+        for r in int_rows:
+            score = float(r["score"])
+            df = float(r["decay_factor"])
+            cands.append(
+                CandidateView(
+                    id=str(r["id"]),
+                    kind="internal",
+                    title=r["distilled_topic"],
+                    summary=r["distilled_angle"],
+                    score=score,
+                    decay_factor=df,
+                    effective_score=score * df,
+                    rank_in_batch=r["rank_in_batch"],
+                    operator_rank=r["operator_rank"],
+                    operator_edited_topic=r["operator_edited_topic"],
+                    operator_edited_angle=r["operator_edited_angle"],
+                    score_breakdown=_loads(r["score_breakdown"]) or {},
+                )
+            )
+        cands.sort(key=lambda c: -c.effective_score)
+        return BatchView(
+            id=batch["id"],
+            niche_id=batch["niche_id"],
+            status=batch["status"],
+            picked_candidate_id=batch["picked_candidate_id"],
+            candidates=cands,
+        )
+
+    async def rank_batch(
+        self, *, batch_id: UUID, ordered_candidate_ids: list[str],
+    ) -> None:
+        """Set ``operator_rank`` on each candidate by its 1-based position
+        in ``ordered_candidate_ids``.
+
+        Tries ``topic_candidates`` first; if the UPDATE affected zero
+        rows, falls back to ``internal_topic_candidates``. asyncpg
+        returns the SQL command tag (e.g. ``"UPDATE 1"`` /
+        ``"UPDATE 0"``) — we sniff the trailing digit to decide whether
+        to fall through.
+        """
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                for rank, cand_id in enumerate(ordered_candidate_ids, start=1):
+                    updated = await conn.execute(
+                        "UPDATE topic_candidates SET operator_rank = $1 "
+                        "WHERE id = $2 AND batch_id = $3",
+                        rank, cand_id, batch_id,
+                    )
+                    if updated.endswith("0"):
+                        await conn.execute(
+                            "UPDATE internal_topic_candidates "
+                            "SET operator_rank = $1 "
+                            "WHERE id = $2 AND batch_id = $3",
+                            rank, cand_id, batch_id,
+                        )
+
+    async def edit_winner(
+        self,
+        *,
+        batch_id: UUID,
+        topic: str | None = None,
+        angle: str | None = None,
+    ) -> None:
+        """Edit the candidate currently ranked #1 by the operator.
+
+        Probes ``topic_candidates`` first; falls back to
+        ``internal_topic_candidates`` if no rank-1 row is found there.
+        Raises ``ValueError`` if neither table has a rank-1 candidate so
+        callers can prompt for ranking before editing.
+        """
+        async with self._pool.acquire() as conn:
+            rid = await conn.fetchval(
+                "SELECT id FROM topic_candidates "
+                "WHERE batch_id = $1 AND operator_rank = 1",
+                batch_id,
+            )
+            tbl = "topic_candidates"
+            if rid is None:
+                rid = await conn.fetchval(
+                    "SELECT id FROM internal_topic_candidates "
+                    "WHERE batch_id = $1 AND operator_rank = 1",
+                    batch_id,
+                )
+                tbl = "internal_topic_candidates"
+            if rid is None:
+                raise ValueError(
+                    f"no rank-1 candidate in batch {batch_id}; rank first",
+                )
+            await conn.execute(
+                f"UPDATE {tbl} "
+                "SET operator_edited_topic = $1, operator_edited_angle = $2 "
+                "WHERE id = $3",
+                topic, angle, rid,
+            )
+
+    async def resolve_batch(self, *, batch_id: UUID) -> None:
+        """Resolve the batch: hand the rank-1 candidate to the content
+        pipeline, then mark the batch ``resolved`` + record provenance.
+
+        Raises ``ValueError`` if no operator_rank=1 candidate exists.
+        """
+        view = await self.show_batch(batch_id=batch_id)
+        winner = next(
+            (c for c in view.candidates if c.operator_rank == 1), None,
+        )
+        if winner is None:
+            raise ValueError("no operator_rank=1 candidate; rank first")
+        niche = await self._niche_svc.get_by_id(view.niche_id)
+        # Pass batch_id explicitly so content_tasks.topic_batch_id
+        # provenance points at the batch (not the candidate). The
+        # candidate id can be reconstructed from picked_candidate_id +
+        # picked_candidate_kind on the batch row itself.
+        await self._handoff_to_pipeline(winner, niche, batch_id)
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE topic_batches
+                   SET status = 'resolved',
+                       resolved_at = NOW(),
+                       picked_candidate_id = $1,
+                       picked_candidate_kind = $2
+                 WHERE id = $3
+                """,
+                winner.id, winner.kind, batch_id,
+            )
+        logger.info(
+            "Batch %s resolved (winner=%s kind=%s)",
+            batch_id, winner.id, winner.kind,
+        )
+
+    async def reject_batch(
+        self, *, batch_id: UUID, reason: str = "",
+    ) -> None:
+        """Reject the batch — flips status to ``expired`` and records
+        ``resolved_at`` so the partial unique index frees up the
+        one-open-batch-per-niche slot for the next sweep."""
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE topic_batches "
+                "SET status = 'expired', resolved_at = NOW() WHERE id = $1",
+                batch_id,
+            )
+        logger.info("Batch %s rejected (reason=%r)", batch_id, reason)
+
+    async def _handoff_to_pipeline(
+        self,
+        winner: CandidateView,
+        niche: Niche,
+        batch_id: UUID,
+    ) -> None:
+        """Advance the winning candidate into the existing content
+        pipeline by inserting a ``content_tasks`` row.
+
+        Uses the operator-edited topic/angle when present, otherwise
+        falls back to the candidate's title/summary.
+
+        ``topic_batch_id`` carries the BATCH id (provenance pointer back
+        to the batch the topic came from), NOT the candidate id — the
+        plan body originally threaded ``winner.id`` here, which would
+        have made provenance point at the candidate row that owns the
+        topic and broken the FK to ``topic_batches``.
+        """
+        topic = winner.operator_edited_topic or winner.title
+        angle = winner.operator_edited_angle or winner.summary or ""
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO content_tasks
+                  (topic, description, status, stage,
+                   niche_slug, writer_rag_mode, topic_batch_id)
+                VALUES ($1, $2, 'pending', 'pending', $3, $4, $5)
+                """,
+                topic, angle, niche.slug, niche.writer_rag_mode, batch_id,
+            )
+
 
 def _json(obj: Any) -> str:
     return json.dumps(obj, default=str)
+
+
+def _loads(value: Any) -> dict[str, float] | None:
+    """Coerce a JSONB column value into a plain dict.
+
+    asyncpg returns JSONB as already-decoded dicts in most setups, but
+    falls back to raw strings if the codec isn't registered. Handle
+    both shapes so ``show_batch`` doesn't depend on connection-level
+    codec config.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (ValueError, TypeError):
+            return None
+    return None

--- a/src/cofounder_agent/services/topic_batch_service.py
+++ b/src/cofounder_agent/services/topic_batch_service.py
@@ -672,13 +672,20 @@ class TopicBatchService:
         """
         topic = winner.operator_edited_topic or winner.title
         angle = winner.operator_edited_angle or winner.summary or ""
+        # task_id, task_type, and content_type are NOT NULL on
+        # content_tasks; the legacy code path (topic_discovery.py:344)
+        # supplies task_id via gen_random_uuid()::text and sets both
+        # task_type and content_type to 'blog_post'. Mirror that here so
+        # the INSERT doesn't trip NotNullViolationError at runtime.
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
                 INSERT INTO content_tasks
-                  (topic, description, status, stage,
+                  (task_id, task_type, content_type,
+                   topic, description, status, stage,
                    niche_slug, writer_rag_mode, topic_batch_id)
-                VALUES ($1, $2, 'pending', 'pending', $3, $4, $5)
+                VALUES (gen_random_uuid()::text, 'blog_post', 'blog_post',
+                        $1, $2, 'pending', 'pending', $3, $4, $5)
                 """,
                 topic, angle, niche.slug, niche.writer_rag_mode, batch_id,
             )

--- a/src/cofounder_agent/services/topic_batch_service.py
+++ b/src/cofounder_agent/services/topic_batch_service.py
@@ -283,7 +283,8 @@ class TopicBatchService:
             # External candidates are dicts (carry-forward rows or plugin
             # output). Carry-forward rows have a "row" key; fresh discovery
             # output is the dict itself.
-            row = item.get("row") if isinstance(item, dict) and "row" in item else item
+            row = item["row"] if isinstance(item, dict) and "row" in item else item
+            assert row is not None
             text = (row.get("title") or "") + " " + (row.get("summary") or "")
             decay = item.get("decay_factor", 1.0) if isinstance(item, dict) else 1.0
             score, breakdown = await score_one(text, decay)

--- a/src/cofounder_agent/services/topic_ranking.py
+++ b/src/cofounder_agent/services/topic_ranking.py
@@ -51,6 +51,13 @@ async def _embed_text_cached(text: str) -> list[float]:
     return await provider.embed(text, model="nomic-embed-text")
 
 
+async def embed_text(text: str) -> list[float]:
+    """Public embedding helper. Writer modes and the batch service import
+    this rather than reaching into ``_embed_text_cached`` directly.
+    """
+    return await _embed_text_cached(text)
+
+
 async def goal_vector_for(goal_type: str) -> list[float]:
     if goal_type in _GOAL_VEC_CACHE:
         return _GOAL_VEC_CACHE[goal_type]

--- a/src/cofounder_agent/services/topic_ranking.py
+++ b/src/cofounder_agent/services/topic_ranking.py
@@ -100,3 +100,84 @@ def weighted_cosine_score(
         breakdown[g.goal_type] = contribution
         total += contribution
     return total, breakdown
+
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class ScoredCandidate:
+    id: str
+    title: str
+    summary: str | None
+    embedding_score: float
+    llm_score: float | None = None
+    score_breakdown: dict[str, float] | None = None
+
+
+async def _ollama_chat_json(prompt: str, *, model: str) -> str:
+    """One-shot Ollama chat call; returns the assistant's content as a string.
+    Indirection so tests can monkeypatch.
+    """
+    import httpx
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "format": "json",
+    }
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post("http://localhost:11434/api/chat", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+    return data["message"]["content"]
+
+
+async def llm_final_score(
+    candidates: list[ScoredCandidate],
+    weights: list[NicheGoal],
+    *,
+    model: str = "glm-4.7-5090:latest",
+) -> dict[str, ScoredCandidate]:
+    """Single LLM call ranks the (already-shortlisted) candidates against weighted goals.
+
+    Returns the same candidates with `llm_score` and `score_breakdown` filled in,
+    keyed by candidate id.
+    """
+    weights_descr = "\n".join(f"- {g.goal_type} (weight {g.weight_pct}%): {GOAL_DESCRIPTIONS[g.goal_type]}" for g in weights)
+    cand_block = "\n".join(f"[{c.id}] {c.title} — {c.summary or ''}" for c in candidates)
+    prompt = f"""You are scoring topic candidates for a content pipeline against the operator's weighted goals.
+
+Goals (weight in pct):
+{weights_descr}
+
+Candidates:
+{cand_block}
+
+Return STRICT JSON keyed by candidate id, of the form:
+{{"<id>": {{"score": <0-100>, "breakdown": {{"<GOAL_TYPE>": <weighted contribution 0-1>, ...}}}}, ...}}
+
+The breakdown values per candidate should approximately sum to (score / 100).
+Return ONLY the JSON, no commentary.
+"""
+    raw = await _ollama_chat_json(prompt, model=model)
+    parsed = json.loads(raw)
+    result: dict[str, ScoredCandidate] = {}
+    for c in candidates:
+        score_blob = parsed.get(c.id)
+        if score_blob is None:
+            logger.warning("LLM scorer omitted candidate %s; defaulting to embedding_score", c.id)
+            score_blob = {"score": c.embedding_score * 100, "breakdown": {}}
+        c.llm_score = float(score_blob.get("score", 0.0))
+        c.score_breakdown = dict(score_blob.get("breakdown", {}))
+        result[c.id] = c
+    return result
+
+
+def apply_decay(*, score: float, decay_factor: float) -> float:
+    """Effective score = raw score × decay_factor. Used both at insertion time
+    (decay_factor=1.0 for fresh, <1.0 for carried-forward) and at re-rank time
+    (carried-forward candidates get an additional decay multiplier applied here).
+    """
+    return score * decay_factor

--- a/src/cofounder_agent/services/topic_ranking.py
+++ b/src/cofounder_agent/services/topic_ranking.py
@@ -6,8 +6,6 @@ Spec §"Goal vectors", §"Discovery sweep" steps 4-5.
 from __future__ import annotations
 
 import math
-from functools import lru_cache
-from typing import Any
 
 from services.logger_config import get_logger
 from services.niche_service import NicheGoal
@@ -32,11 +30,25 @@ _GOAL_VEC_CACHE: dict[str, list[float]] = {}
 
 
 async def _embed_text_cached(text: str) -> list[float]:
-    """Embed via the existing service; the embedding service is responsible
-    for its own caching (or not). This indirection lets tests monkeypatch.
+    """Embed via the registered ollama_native provider.
+
+    The embedding service is responsible for its own caching (or not).
+    This indirection exists so tests can monkeypatch.
+
+    NB: The plan spec referenced ``from services.embedding_service import
+    embed_text`` but no such module-level helper exists — embeddings go
+    through the ``LLMProvider`` Protocol (matches the pattern in
+    ``services.publish_service`` etc.).
     """
-    from services.embedding_service import embed_text
-    return await embed_text(text)
+    from plugins.registry import get_llm_providers
+
+    providers = {p.name: p for p in get_llm_providers()}
+    provider = providers.get("ollama_native")
+    if provider is None:
+        raise RuntimeError(
+            "ollama_native provider not registered — cannot generate embeddings"
+        )
+    return await provider.embed(text, model="nomic-embed-text")
 
 
 async def goal_vector_for(goal_type: str) -> list[float]:

--- a/src/cofounder_agent/services/topic_ranking.py
+++ b/src/cofounder_agent/services/topic_ranking.py
@@ -1,0 +1,83 @@
+"""Topic candidate ranking — goal vectors + hybrid embed/LLM scoring + decay rerank.
+
+Spec §"Goal vectors", §"Discovery sweep" steps 4-5.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+from typing import Any
+
+from services.logger_config import get_logger
+from services.niche_service import NicheGoal
+
+logger = get_logger(__name__)
+
+
+# Per the spec — fixed prose anchor for each goal type. Cached embeddings
+# are computed lazily on first use and live for the process lifetime.
+GOAL_DESCRIPTIONS: dict[str, str] = {
+    "TRAFFIC":     "Topic likely to attract organic search traffic; trending keyword, broad appeal, evergreen demand.",
+    "EDUCATION":   "Topic that teaches the reader something concrete and useful they didn't know before.",
+    "BRAND":       "Topic that reinforces the operator's positioning and unique perspective.",
+    "AUTHORITY":   "Topic that demonstrates the operator's depth and expertise on something specific.",
+    "REVENUE":     "Topic that drives a commercial outcome: signups, sales, conversions, paid feature awareness.",
+    "COMMUNITY":   "Topic that resonates with the operator's existing audience; sparks discussion, shares, replies.",
+    "NICHE_DEPTH": "Topic that goes deep on the operator's niche specialty rather than broad-audience content.",
+}
+
+
+_GOAL_VEC_CACHE: dict[str, list[float]] = {}
+
+
+async def _embed_text_cached(text: str) -> list[float]:
+    """Embed via the existing service; the embedding service is responsible
+    for its own caching (or not). This indirection lets tests monkeypatch.
+    """
+    from services.embedding_service import embed_text
+    return await embed_text(text)
+
+
+async def goal_vector_for(goal_type: str) -> list[float]:
+    if goal_type in _GOAL_VEC_CACHE:
+        return _GOAL_VEC_CACHE[goal_type]
+    if goal_type not in GOAL_DESCRIPTIONS:
+        raise ValueError(f"unknown goal_type: {goal_type!r}")
+    vec = await _embed_text_cached(GOAL_DESCRIPTIONS[goal_type])
+    _GOAL_VEC_CACHE[goal_type] = vec
+    return vec
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def weighted_cosine_score(
+    candidate_vec: list[float],
+    goal_vecs: dict[str, list[float]],
+    weights: list[NicheGoal],
+) -> tuple[float, dict[str, float]]:
+    """Returns (overall_score, per_goal_breakdown).
+
+    overall_score = sum over goals of (cosine(candidate, goal_vec) * weight_pct/100).
+    breakdown maps goal_type -> its weighted contribution.
+    """
+    breakdown: dict[str, float] = {}
+    total = 0.0
+    for g in weights:
+        gv = goal_vecs.get(g.goal_type)
+        if gv is None:
+            continue
+        cos = cosine_similarity(candidate_vec, gv)
+        contribution = cos * (g.weight_pct / 100.0)
+        breakdown[g.goal_type] = contribution
+        total += contribution
+    return total, breakdown

--- a/src/cofounder_agent/services/writer_rag_modes/__init__.py
+++ b/src/cofounder_agent/services/writer_rag_modes/__init__.py
@@ -1,0 +1,48 @@
+"""Writer RAG mode dispatcher.
+
+The writer stage of the content pipeline delegates to one of four handlers
+based on the niche's writer_rag_mode setting. Each handler produces a draft
+with a different RAG strategy:
+
+- TOPIC_ONLY        — single embedding query, dump top-N snippets in prompt
+- CITATION_BUDGET   — same as TOPIC_ONLY but writer required to cite >= N
+- STORY_SPINE       — outline-first pass, then expand to prose
+- TWO_PASS          — internal-first draft, then conditional external augment
+                      (LangGraph state machine; Glad Labs default)
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 9)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+
+async def dispatch_writer_mode(
+    *,
+    mode: str,
+    topic: str,
+    angle: str,
+    niche_id: UUID | str,
+    pool,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Route the writer call to the right mode handler. Each handler returns
+    the writer's output dict (at minimum {"draft": "..."} plus any metadata).
+    """
+    if mode == "TOPIC_ONLY":
+        from services.writer_rag_modes import topic_only
+        return await topic_only.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "CITATION_BUDGET":
+        from services.writer_rag_modes import citation_budget
+        return await citation_budget.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "STORY_SPINE":
+        from services.writer_rag_modes import story_spine
+        return await story_spine.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    elif mode == "TWO_PASS":
+        from services.writer_rag_modes import two_pass
+        return await two_pass.run(topic=topic, angle=angle, niche_id=niche_id, pool=pool, **kwargs)
+    else:
+        raise ValueError(f"unknown writer_rag_mode: {mode!r}")

--- a/src/cofounder_agent/services/writer_rag_modes/citation_budget.py
+++ b/src/cofounder_agent/services/writer_rag_modes/citation_budget.py
@@ -1,0 +1,66 @@
+"""CITATION_BUDGET writer mode.
+
+Same as TOPIC_ONLY but the writer is REQUIRED to cite at least N internal
+sources by [source/ref] tag. content_validator extension (follow-up) enforces
+the count post-write.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 11)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_MIN_CITATIONS = 3
+
+
+async def run(
+    *,
+    topic: str,
+    angle: str,
+    niche_id: UUID | str,
+    pool,
+    min_citations: int = DEFAULT_MIN_CITATIONS,
+    **kw: Any,
+) -> dict[str, Any]:
+    from services.topic_ranking import embed_text
+
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 12
+            """,
+            qvec,
+        )
+    snippets = [
+        {"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
+        for r in rows
+    ]
+
+    citation_instruction = (
+        f"You MUST cite at least {min_citations} of the provided internal sources by their "
+        f"source/ref pair (e.g. [claude_sessions/abc123]). Failing to cite that many will "
+        f"cause the post to be rejected by the validator."
+    )
+    from services.ai_content_generator import generate_with_context
+
+    draft = await generate_with_context(
+        topic=topic, angle=angle, snippets=snippets,
+        extra_instructions=citation_instruction,
+    )
+    return {
+        "draft": draft,
+        "snippets_used": snippets,
+        "min_citations": min_citations,
+        "mode": "CITATION_BUDGET",
+    }

--- a/src/cofounder_agent/services/writer_rag_modes/story_spine.py
+++ b/src/cofounder_agent/services/writer_rag_modes/story_spine.py
@@ -1,0 +1,62 @@
+"""STORY_SPINE writer mode.
+
+Preprocess top snippets into a structured outline with one LLM call, then
+expand the outline to full prose with the writer.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 12)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    from services.topic_ranking import _ollama_chat_json, embed_text
+
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 15
+            """,
+            qvec,
+        )
+    snippets = [
+        {"source": r["source_table"], "ref": str(r["source_id"]), "snippet": r["text_preview"]}
+        for r in rows
+    ]
+    snippet_block = "\n---\n".join(s["snippet"][:600] for s in snippets if s["snippet"])
+
+    spine_prompt = f"""Read these 15 snippets from an AI-operated content business's records.
+Produce a structured outline for a blog post about: "{topic}" (angle: "{angle}").
+
+Outline format (return JSON):
+{{
+  "hook": "<opening hook, one sentence>",
+  "what_happened": "<the timeline of events as drawn from snippets>",
+  "why_it_matters": "<the lesson or insight>",
+  "what_we_learned": "<concrete takeaways>",
+  "close": "<call-to-action or final framing>"
+}}
+
+Snippets:
+{snippet_block}
+"""
+    spine_raw = await _ollama_chat_json(spine_prompt, model="glm-4.7-5090:latest")
+    spine = json.loads(spine_raw)
+
+    from services.ai_content_generator import generate_with_outline
+
+    draft = await generate_with_outline(topic=topic, outline=spine, snippets=snippets)
+    return {"draft": draft, "spine": spine, "snippets_used": snippets, "mode": "STORY_SPINE"}

--- a/src/cofounder_agent/services/writer_rag_modes/topic_only.py
+++ b/src/cofounder_agent/services/writer_rag_modes/topic_only.py
@@ -1,0 +1,49 @@
+"""TOPIC_ONLY writer mode.
+
+Single embedding query, dump top-N internal snippets into the writer prompt
+as background context. Simplest of the four modes.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 10)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    from services.topic_ranking import embed_text
+
+    qvec = await embed_text(f"{topic} — {angle}")
+    async with pool.acquire() as conn:
+        # Top 8 internal snippets by cosine similarity. Uses pgvector.
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview,
+                   1 - (embedding <=> $1::vector) AS similarity
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 8
+            """,
+            qvec,
+        )
+    snippets = [
+        {
+            "source": r["source_table"],
+            "ref": str(r["source_id"]),
+            "snippet": r["text_preview"],
+            "similarity": float(r["similarity"]),
+        }
+        for r in rows
+    ]
+    # Hand off to the existing writer with the snippets in the prompt context.
+    from services.ai_content_generator import generate_with_context
+
+    draft = await generate_with_context(topic=topic, angle=angle, snippets=snippets)
+    return {"draft": draft, "snippets_used": snippets, "mode": "TOPIC_ONLY"}

--- a/src/cofounder_agent/services/writer_rag_modes/two_pass.py
+++ b/src/cofounder_agent/services/writer_rag_modes/two_pass.py
@@ -1,0 +1,218 @@
+"""TWO_PASS — internal-first draft, then conditional external fact-augmentation
+loop. Implemented as a LangGraph state machine because:
+
+- Multi-pass with conditional re-entry (revise can surface new
+  [EXTERNAL_NEEDED] markers that need another research pass)
+- Bounded loop (_MAX_REVISION_LOOPS=3 prevents runaway)
+- Future-friendly: when we add an auto-researcher agent or a draft-critic
+  loop, they slot in as new nodes/edges rather than refactoring orchestration
+
+Spec §"OSS leverage decisions" — TWO_PASS is the only writer mode using
+LangGraph; the simpler modes (TOPIC_ONLY, CITATION_BUDGET, STORY_SPINE)
+stay plain Python because they don't have branching.
+
+State flow:
+
+    embed_and_fetch → draft → detect_needs ┐
+                                            │ if needs found and loops < max:
+                                            ↓
+                                  research_each → revise ─┐
+                                                           │
+                                                           ↓
+                                                  detect_needs (loop)
+                                                           │
+                                                           ↓ if no needs OR loops capped
+                                                          END
+
+Deviations from plan:
+
+- Imports `embed_text` from `services.topic_ranking` instead of
+  `services.embedding_service` because the embedding_service module has
+  no module-level `embed_text` helper — that helper lives in topic_ranking.
+- Stores the asyncpg pool in a module-level `_POOL_REGISTRY` keyed by
+  thread_id rather than directly in graph state. The MemorySaver
+  checkpointer msgpack-serializes state on every step; an asyncpg.Pool
+  (or a MagicMock thereof) is not serializable and recurses through
+  attribute access. Holding the pool out-of-band keeps state msgpack-clean
+  while preserving the same per-thread isolation the plan called for.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, TypedDict
+from uuid import UUID
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.memory import MemorySaver
+
+from services.logger_config import get_logger
+
+# Module-level keyed-by-thread store for non-serializable state (the asyncpg
+# pool). The MemorySaver checkpointer serializes state via msgpack, and an
+# asyncpg.Pool is not msgpack-able (and a MagicMock pool in tests recurses
+# forever during attribute introspection). Holding the pool out-of-band lets
+# checkpointing serialize only the data it needs (snippets, drafts, needs).
+_POOL_REGISTRY: dict[str, Any] = {}
+
+logger = get_logger(__name__)
+
+
+_MAX_REVISION_LOOPS = 3
+_NEED_PATTERN = re.compile(r"\[EXTERNAL_NEEDED:\s*([^\]]+)\]")
+
+
+class _State(TypedDict, total=False):
+    topic: str
+    angle: str
+    snippets: list[dict[str, Any]]
+    # NOTE: `pool` is NOT stored in state — it's a non-serializable
+    # asyncpg.Pool (or test MagicMock) and would crash msgpack in the
+    # checkpointer. See _POOL_REGISTRY above. We keep the field in the
+    # TypedDict for type-shape compatibility but never write it.
+    pool_thread: str  # lookup key into _POOL_REGISTRY
+    draft: str
+    needs: list[str]
+    research_results: list[dict[str, Any]]
+    external_lookups: list[dict[str, Any]]
+    revision_loops: int
+    loop_capped: bool
+
+
+# -- nodes --
+
+async def _embed_and_fetch_snippets(state: _State) -> _State:
+    from services.topic_ranking import embed_text
+    qvec = await embed_text(f"{state['topic']} — {state['angle']}")
+    pool = _POOL_REGISTRY[state["pool_thread"]]
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT source_table, source_id, text_preview
+              FROM embeddings
+             ORDER BY embedding <=> $1::vector
+             LIMIT 20
+            """,
+            qvec,
+        )
+    snippets = [{"source": r["source_table"], "ref": str(r["source_id"]),
+                 "snippet": r["text_preview"]} for r in rows]
+    return {**state, "snippets": snippets, "revision_loops": 0,
+            "external_lookups": [], "loop_capped": False}
+
+
+async def _draft_node(state: _State) -> _State:
+    from services.ai_content_generator import generate_with_context
+    instruction = (
+        "Write a first-draft blog post drawing ONLY from the provided internal "
+        "snippets. Do NOT make up external facts, statistics, or quotes you cannot "
+        "ground in a snippet. If you need an outside fact you don't have, mark it "
+        "[EXTERNAL_NEEDED: <description>] in the draft so a follow-up pass can fill it in."
+    )
+    draft = await generate_with_context(
+        topic=state["topic"], angle=state["angle"],
+        snippets=state["snippets"], extra_instructions=instruction,
+    )
+    return {**state, "draft": draft}
+
+
+def _detect_needs(state: _State) -> _State:
+    needs = _NEED_PATTERN.findall(state["draft"])
+    return {**state, "needs": [n.strip() for n in needs]}
+
+
+async def _research_each(state: _State) -> _State:
+    from services.research_service import research_topic
+    results = []
+    for need in state["needs"]:
+        aug = await research_topic(query=need, max_sources=2)
+        results.append({"need": need, "research": aug})
+    cumulative = list(state.get("external_lookups") or []) + results
+    return {**state, "research_results": results, "external_lookups": cumulative}
+
+
+async def _revise_node(state: _State) -> _State:
+    from services.topic_ranking import _ollama_chat_json
+    aug_block = "\n\n".join(
+        f"[EXTERNAL_NEEDED: {r['need']}] → {r['research']}"
+        for r in state["research_results"]
+    )
+    revise_prompt = f"""Revise the following draft. For each [EXTERNAL_NEEDED: ...] marker,
+substitute the corresponding external fact provided below. Keep everything else unchanged.
+If revision exposes a new claim that needs outside support, mark it [EXTERNAL_NEEDED: ...]
+again so the next pass can fill it.
+
+Original draft:
+{state['draft']}
+
+External facts:
+{aug_block}
+"""
+    new_draft = await _ollama_chat_json(revise_prompt, model="glm-4.7-5090:latest")
+    return {**state, "draft": new_draft, "revision_loops": state.get("revision_loops", 0) + 1}
+
+
+def _mark_capped(state: _State) -> _State:
+    return {**state, "loop_capped": True}
+
+
+# -- conditional edges --
+
+def _needs_or_done(state: _State) -> str:
+    """After detect_needs: route to research_each if needs found AND we haven't
+    hit the loop cap, else END (or _done_capped if we're capping)."""
+    if not state.get("needs"):
+        return END
+    if state.get("revision_loops", 0) >= _MAX_REVISION_LOOPS:
+        return "_done_capped"
+    return "research_each"
+
+
+def _build_graph():
+    g = StateGraph(_State)
+    g.add_node("embed_and_fetch", _embed_and_fetch_snippets)
+    g.add_node("draft", _draft_node)
+    g.add_node("detect_needs", _detect_needs)
+    g.add_node("research_each", _research_each)
+    g.add_node("revise", _revise_node)
+    g.add_node("_done_capped", _mark_capped)
+
+    g.set_entry_point("embed_and_fetch")
+    g.add_edge("embed_and_fetch", "draft")
+    g.add_edge("draft", "detect_needs")
+    g.add_conditional_edges("detect_needs", _needs_or_done, {
+        "research_each": "research_each",
+        "_done_capped": "_done_capped",
+        END: END,
+    })
+    g.add_edge("research_each", "revise")
+    g.add_edge("revise", "detect_needs")
+    g.add_edge("_done_capped", END)
+
+    # MemorySaver checkpointer means the graph CAN be paused mid-run and
+    # resumed — useful when an operator interrupts mid-revision in v2.
+    # v1 uses in-memory; v2 swaps to a postgres checkpointer for
+    # cross-process durability.
+    return g.compile(checkpointer=MemorySaver())
+
+
+_GRAPH = _build_graph()
+
+
+async def run(*, topic: str, angle: str, niche_id: UUID | str, pool, **kw: Any) -> dict[str, Any]:
+    thread_id = f"two_pass-{niche_id}-{topic[:32]}"
+    _POOL_REGISTRY[thread_id] = pool
+    try:
+        initial: _State = {"topic": topic, "angle": angle, "pool_thread": thread_id}
+        config = {"configurable": {"thread_id": thread_id}}
+        final = await _GRAPH.ainvoke(initial, config=config)
+        return {
+            "draft": final["draft"],
+            "snippets_used": final.get("snippets", []),
+            "external_lookups": final.get("external_lookups", []),
+            "revision_loops": final.get("revision_loops", 0),
+            "loop_capped": final.get("loop_capped", False),
+            "mode": "TWO_PASS",
+        }
+    finally:
+        _POOL_REGISTRY.pop(thread_id, None)

--- a/src/cofounder_agent/tests/integration/test_niche_discovery_e2e.py
+++ b/src/cofounder_agent/tests/integration/test_niche_discovery_e2e.py
@@ -1,0 +1,328 @@
+"""Integration: end-to-end niche topic-discovery flow.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 18)
+
+Two scenarios:
+
+1. ``test_glad_labs_sweep_produces_a_batch`` — verifies the seeded
+   ``glad-labs`` niche exists, runs a full sweep against the test DB,
+   and asserts an open batch with at least one candidate is created.
+2. ``test_resolve_advances_to_content_task`` — manually seeds a batch +
+   candidate, ranks + resolves, and asserts a ``content_tasks`` row
+   landed with the right ``niche_slug`` / ``writer_rag_mode`` /
+   ``topic_batch_id`` provenance.
+
+Self-contained DB fixture
+=========================
+The unit-tier ``db_pool`` fixture (``tests/unit/conftest.py``) is not on
+this directory's conftest chain, and the integration tier's existing
+``real_pool`` fixture is gated behind ``INTEGRATION_TESTS=1`` +
+``REAL_SERVICES_TESTS=1`` and only loads ``init_test_schema.sql`` (not
+the niche migrations 0113-0115). To keep this file standalone + self-
+hermetic, we redefine the same disposable-test-DB pattern here. The
+fixture skips the whole module if no live Postgres DSN is reachable.
+"""
+
+from __future__ import annotations
+
+import secrets
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+import pytest_asyncio
+
+from services.internal_rag_source import InternalCandidate
+from services.niche_service import NicheService
+from services.topic_batch_service import TopicBatchService
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session"), pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Disposable DB fixture (mirrors unit-tier ``db_pool``)
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_resolve_dsn() -> str | None:
+    """Walk the tree up until we find brain/bootstrap.py, then call its
+    resolver. Same trick the unit-tier + integration_db conftests use.
+    """
+    for p in Path(__file__).resolve().parents:
+        if (p / "brain" / "bootstrap.py").is_file():
+            if str(p) not in sys.path:
+                sys.path.insert(0, str(p))
+            break
+    try:
+        from brain.bootstrap import resolve_database_url
+
+        return resolve_database_url()
+    except Exception:
+        return None
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def _e2e_db_pool_session():
+    """Session-scoped asyncpg pool against a disposable test database.
+
+    Creates a fresh ``poindexter_e2e_<hex>`` database, replays the
+    infrastructure init.sql + every migration in
+    ``services/migrations/`` (so the seed of ``glad-labs`` from 0115 is
+    applied), and yields a pool. Drops the database at session teardown.
+
+    Skips the whole module if no live Postgres DSN is reachable so a
+    unit-only CI runner doesn't blow up.
+    """
+    import asyncpg
+
+    base = _bootstrap_resolve_dsn()
+    if not base or base == "postgresql://test:test@localhost/test":
+        pytest.skip(
+            "No live Postgres DSN configured — niche e2e test requires a reachable DB"
+        )
+
+    parsed = urlparse(base)
+    admin_dsn = urlunparse(parsed._replace(path="/postgres"))
+    test_db_name = f"poindexter_e2e_{secrets.token_hex(6)}"
+    test_dsn = urlunparse(parsed._replace(path=f"/{test_db_name}"))
+
+    admin = await asyncpg.connect(admin_dsn)
+    try:
+        await admin.execute(f"DROP DATABASE IF EXISTS {test_db_name}")
+        await admin.execute(f"CREATE DATABASE {test_db_name}")
+    finally:
+        await admin.close()
+
+    fresh = await asyncpg.connect(test_dsn)
+    try:
+        await fresh.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        await fresh.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+        for p in Path(__file__).resolve().parents:
+            init_sql = p / "infrastructure" / "local-db" / "init.sql"
+            if init_sql.is_file():
+                try:
+                    await fresh.execute(init_sql.read_text(encoding="utf-8"))
+                except Exception:
+                    pass
+                break
+    finally:
+        await fresh.close()
+
+    pool = await asyncpg.create_pool(test_dsn, min_size=1, max_size=4)
+    try:
+        from services.migrations import run_migrations
+
+        class _StubService:
+            def __init__(self, pool):
+                self.pool = pool
+
+        ok = await run_migrations(_StubService(pool))
+        if not ok:
+            pytest.fail("Migrations failed against the niche e2e test DB")
+
+        try:
+            yield pool
+        finally:
+            await pool.close()
+    finally:
+        admin = await asyncpg.connect(admin_dsn)
+        try:
+            await admin.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = $1 AND pid <> pg_backend_pid()",
+                test_db_name,
+            )
+            await admin.execute(f"DROP DATABASE IF EXISTS {test_db_name}")
+        finally:
+            await admin.close()
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db_pool(_e2e_db_pool_session):
+    """Per-test wrapper that cleans up content_tasks between tests.
+
+    Niches are NOT truncated — the seeded ``glad-labs`` niche from
+    migration 0115 must persist for Test 1 even if it runs second, and
+    Test 2 creates its own ad-hoc niche so cross-test slug collision
+    isn't a concern (each test uses a unique slug).
+    """
+    try:
+        yield _e2e_db_pool_session
+    finally:
+        async with _e2e_db_pool_session.acquire() as conn:
+            try:
+                # Wipe content_tasks the test inserted so re-runs in the
+                # same session don't accumulate. niche_slug IS NOT NULL
+                # is the marker that distinguishes our test rows from
+                # any rows the migrations themselves may have seeded.
+                await conn.execute(
+                    "DELETE FROM content_tasks WHERE niche_slug IS NOT NULL"
+                )
+            except Exception:
+                pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_goal_vec_cache():
+    """``services.topic_ranking._GOAL_VEC_CACHE`` is module-level and
+    persists for the process lifetime. Clear between tests so the second
+    test doesn't inherit the first's monkeypatched fake vectors.
+    """
+    from services.topic_ranking import _GOAL_VEC_CACHE
+
+    _GOAL_VEC_CACHE.clear()
+    yield
+    _GOAL_VEC_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — full sweep against the seeded glad-labs niche
+# ---------------------------------------------------------------------------
+
+
+async def test_glad_labs_sweep_produces_a_batch(db_pool, monkeypatch):
+    """Run a sweep against the seeded glad-labs niche and assert it
+    produces an open batch with at least one candidate.
+
+    The sweep would normally call real Ollama for embeddings + LLM
+    scoring — both are monkeypatched to deterministic fakes so the test
+    is hermetic. ``InternalRagSource.generate`` is also faked so the
+    test doesn't depend on real embedding rows existing in the test DB.
+    """
+    nsvc = NicheService(db_pool)
+    n = await nsvc.get_by_slug("glad-labs")
+    assert n is not None, "glad-labs niche should be seeded by migration 0115"
+
+    # Mock the internal source so we don't need real embeddings rows.
+    async def fake_internal_generate(self, **kwargs):
+        return [
+            InternalCandidate(
+                source_kind="claude_session",
+                primary_ref=f"glad-{i}",
+                distilled_topic=f"Glad Labs Topic {i}",
+                distilled_angle=f"Angle {i}",
+            )
+            for i in range(5)
+        ]
+
+    monkeypatch.setattr(
+        "services.internal_rag_source.InternalRagSource.generate",
+        fake_internal_generate,
+    )
+
+    # Hermetic embedding + LLM scoring — patch the source module so the
+    # lazy imports inside TopicBatchService pick up the fakes.
+    async def fake_embed_text(text):
+        return [0.1] * 768
+
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed_text)
+    monkeypatch.setattr(
+        "services.topic_ranking._embed_text_cached", fake_embed_text,
+    )
+
+    async def fake_llm_score(candidates, weights, *, model=None):
+        result = {}
+        for idx, c in enumerate(candidates):
+            c.llm_score = 80 - idx * 5
+            c.score_breakdown = {}
+            result[c.id] = c
+        return result
+
+    monkeypatch.setattr("services.topic_ranking.llm_final_score", fake_llm_score)
+
+    svc = TopicBatchService(db_pool)
+    batch = await svc.run_sweep(niche_id=n.id)
+
+    if batch is None:
+        # Floor not elapsed since a prior run; force it via the test by
+        # wiping discovery_runs and re-sweeping. This mirrors the plan's
+        # "force the floor" instruction.
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM discovery_runs WHERE niche_id = $1", n.id,
+            )
+        batch = await svc.run_sweep(niche_id=n.id)
+
+    assert batch is not None, "sweep must produce a batch"
+    assert batch.status == "open"
+    assert batch.candidate_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — resolve advances winner into content_tasks
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_advances_to_content_task(db_pool, monkeypatch):
+    """End-to-end pick → rank → resolve → content_tasks insert.
+
+    Seeds an isolated niche + open batch + 2 candidates directly via
+    SQL (avoids re-running the discovery flow), ranks them, then calls
+    ``resolve_batch`` and asserts a ``content_tasks`` row landed with
+    the right niche_slug / writer_rag_mode / topic_batch_id provenance.
+    """
+    nsvc = NicheService(db_pool)
+    niche = await nsvc.create(
+        slug="e2e-resolve-niche",
+        name="E2E Resolve",
+        writer_rag_mode="TWO_PASS",
+        batch_size=3,
+    )
+
+    expires = datetime.now(timezone.utc) + timedelta(days=7)
+    cand_ids: list[str] = []
+    async with db_pool.acquire() as conn:
+        batch_row = await conn.fetchrow(
+            "INSERT INTO topic_batches (niche_id, status, expires_at) "
+            "VALUES ($1, 'open', $2) RETURNING id",
+            niche.id, expires,
+        )
+        batch_id = batch_row["id"]
+
+        # Two external candidates so resolve picks the rank-1 of the two.
+        for i in range(2):
+            row = await conn.fetchrow(
+                """
+                INSERT INTO topic_candidates
+                  (batch_id, niche_id, source_name, source_ref, title, summary,
+                   score, score_breakdown, rank_in_batch, decay_factor)
+                VALUES ($1, $2, 'external', $3, $4, $5, $6, '{}'::jsonb, $7, 1.0)
+                RETURNING id
+                """,
+                batch_id, niche.id, f"e2e-ref-{i}",
+                f"E2E Topic {i}", f"E2E summary {i}",
+                90 - i, i + 1,
+            )
+            cand_ids.append(str(row["id"]))
+
+    svc = TopicBatchService(db_pool)
+    # Operator picks candidate 0 as the winner.
+    await svc.rank_batch(batch_id=batch_id, ordered_candidate_ids=cand_ids)
+
+    # Resolve calls _handoff_to_pipeline (real implementation, not mocked)
+    # which inserts the content_tasks row — the assertion target.
+    await svc.resolve_batch(batch_id=batch_id)
+
+    async with db_pool.acquire() as conn:
+        task_row = await conn.fetchrow(
+            "SELECT * FROM content_tasks WHERE topic_batch_id = $1",
+            batch_id,
+        )
+        batch_after = await conn.fetchrow(
+            "SELECT * FROM topic_batches WHERE id = $1", batch_id,
+        )
+
+    assert task_row is not None, "resolve_batch must insert a content_tasks row"
+    assert task_row["niche_slug"] == "e2e-resolve-niche"
+    assert task_row["writer_rag_mode"] == "TWO_PASS"
+    assert task_row["topic_batch_id"] == batch_id
+    assert task_row["topic"] == "E2E Topic 0"
+    assert task_row["status"] == "pending"
+
+    # Batch was marked resolved + picked candidate recorded.
+    assert batch_after["status"] == "resolved"
+    assert str(batch_after["picked_candidate_id"]) == cand_ids[0]
+    assert batch_after["picked_candidate_kind"] == "external"

--- a/src/cofounder_agent/tests/unit/conftest.py
+++ b/src/cofounder_agent/tests/unit/conftest.py
@@ -31,8 +31,13 @@ For now the fixtures reset the shared state between tests.
 from __future__ import annotations
 
 import os
+import secrets
+import sys
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 import pytest
+import pytest_asyncio
 
 from services.site_config import site_config
 
@@ -172,3 +177,128 @@ def _reset_singletons_between_tests():
             container._services = {}
     except Exception:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — optional real-Postgres ``db_pool`` fixture
+# ---------------------------------------------------------------------------
+#
+# Some service tests need to roundtrip SQL against a real Postgres (e.g.
+# tests that exercise CHECK constraints, UNIQUE indexes, or transactional
+# behavior — anything a mock pool would silently let through). These tests
+# request the ``db_pool`` fixture below.
+#
+# Mirrors the integration_db tier's skip pattern: if no live Postgres DSN
+# resolves, the whole module is skipped at fixture time so unit-only CI
+# runners don't blow up.
+
+
+def _bootstrap_resolve_dsn() -> str | None:
+    """Walk the tree up until we find brain/bootstrap.py, then call its
+    resolver. Same trick the integration_db conftest uses.
+    """
+    for p in Path(__file__).resolve().parents:
+        if (p / "brain" / "bootstrap.py").is_file():
+            if str(p) not in sys.path:
+                sys.path.insert(0, str(p))
+            break
+    try:
+        from brain.bootstrap import resolve_database_url
+        return resolve_database_url()
+    except Exception:
+        return None
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def _db_pool_session():
+    """Session-scoped asyncpg pool against a disposable test database.
+
+    Creates a fresh ``poindexter_unit_<hex>`` database, runs every
+    migration in ``services/migrations/`` against it, and yields a pool.
+    Drops the database at session teardown.
+
+    Skips the test if no live Postgres DSN is reachable.
+    """
+    import asyncpg
+
+    base = _bootstrap_resolve_dsn()
+    if not base or base == "postgresql://test:test@localhost/test":
+        pytest.skip(
+            "No live Postgres DSN configured — db_pool fixture requires a reachable DB"
+        )
+
+    parsed = urlparse(base)
+    admin_dsn = urlunparse(parsed._replace(path="/postgres"))
+    test_db_name = f"poindexter_unit_{secrets.token_hex(6)}"
+    test_dsn = urlunparse(parsed._replace(path=f"/{test_db_name}"))
+
+    admin = await asyncpg.connect(admin_dsn)
+    try:
+        await admin.execute(f"DROP DATABASE IF EXISTS {test_db_name}")
+        await admin.execute(f"CREATE DATABASE {test_db_name}")
+    finally:
+        await admin.close()
+
+    # Replay infra init.sql (extensions + base schema) before migrations.
+    fresh = await asyncpg.connect(test_dsn)
+    try:
+        await fresh.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        await fresh.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+        for p in Path(__file__).resolve().parents:
+            init_sql = p / "infrastructure" / "local-db" / "init.sql"
+            if init_sql.is_file():
+                try:
+                    await fresh.execute(init_sql.read_text(encoding="utf-8"))
+                except Exception:
+                    pass
+                break
+    finally:
+        await fresh.close()
+
+    pool = await asyncpg.create_pool(test_dsn, min_size=1, max_size=4)
+    try:
+        from services.migrations import run_migrations
+
+        class _StubService:
+            def __init__(self, pool):
+                self.pool = pool
+
+        ok = await run_migrations(_StubService(pool))
+        if not ok:
+            pytest.fail("Migrations failed against the unit-tier test DB")
+
+        try:
+            yield pool
+        finally:
+            await pool.close()
+    finally:
+        admin = await asyncpg.connect(admin_dsn)
+        try:
+            await admin.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = $1 AND pid <> pg_backend_pid()",
+                test_db_name,
+            )
+            await admin.execute(f"DROP DATABASE IF EXISTS {test_db_name}")
+        finally:
+            await admin.close()
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db_pool(_db_pool_session):
+    """Function-scoped wrapper around the session pool that wipes niche
+    tables after each test so cross-test slug collisions don't leak.
+
+    Tests just request ``db_pool`` — yields the same underlying pool, but
+    handles cleanup transparently.
+    """
+    try:
+        yield _db_pool_session
+    finally:
+        async with _db_pool_session.acquire() as conn:
+            # CASCADE drops dependent rows in niche_goals + niche_sources +
+            # topic_batches + candidates + discovery_runs.
+            try:
+                await conn.execute("TRUNCATE niches CASCADE")
+            except Exception:
+                pass

--- a/src/cofounder_agent/tests/unit/services/test_internal_rag_source.py
+++ b/src/cofounder_agent/tests/unit/services/test_internal_rag_source.py
@@ -1,0 +1,37 @@
+"""Tests for InternalRagSource — generate candidates from internal corpus.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 5)
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+from services.internal_rag_source import InternalRagSource, InternalCandidate
+
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def test_generate_pulls_top_k_per_source_kind(db_pool, monkeypatch):
+    # The source should query the embeddings table for each enabled source_kind
+    # and return distilled candidates.
+    src = InternalRagSource(db_pool)
+    # Mock the LLM distillation step — it turns a snippet into (topic, angle).
+    async def fake_distill(snippets):
+        return ("How we handled OAuth phase 1", "Why client credentials grant first")
+    monkeypatch.setattr(src, "_distill_topic_angle", fake_distill)
+
+    candidates = await src.generate(
+        niche_id="00000000-0000-0000-0000-000000000001",
+        source_kinds=["claude_session", "brain_knowledge"],
+        per_kind_limit=2,
+    )
+    assert all(isinstance(c, InternalCandidate) for c in candidates)
+    # at most 2 * 2 = 4 candidates if data exists for both source_kinds
+    assert len(candidates) <= 4
+    if candidates:
+        c = candidates[0]
+        assert c.distilled_topic
+        assert c.distilled_angle
+        assert c.primary_ref
+        assert isinstance(c.supporting_refs, list)

--- a/src/cofounder_agent/tests/unit/services/test_niche_service.py
+++ b/src/cofounder_agent/tests/unit/services/test_niche_service.py
@@ -9,6 +9,7 @@ is reachable the fixture skips the module so CI runners without a DB
 don't blow up at fixture time — same pattern as the integration_db tier.
 """
 
+import asyncpg
 import pytest
 from services.niche_service import NicheService, Niche, NicheGoal, NicheSource
 
@@ -29,7 +30,7 @@ async def test_create_niche_inserts_row(db_pool):
 async def test_create_niche_rejects_duplicate_slug(db_pool):
     svc = NicheService(db_pool)
     await svc.create(slug="dupe", name="A")
-    with pytest.raises(Exception):
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
         await svc.create(slug="dupe", name="B")
 
 

--- a/src/cofounder_agent/tests/unit/services/test_niche_service.py
+++ b/src/cofounder_agent/tests/unit/services/test_niche_service.py
@@ -1,0 +1,66 @@
+"""Tests for NicheService — CRUD over niches/goals/sources tables.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 2)
+
+These tests roundtrip against a real Postgres test DB (the ``db_pool``
+fixture is provided by ``tests/unit/conftest.py``). When no live Postgres
+is reachable the fixture skips the module so CI runners without a DB
+don't blow up at fixture time — same pattern as the integration_db tier.
+"""
+
+import pytest
+from services.niche_service import NicheService, Niche, NicheGoal, NicheSource
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def test_create_niche_inserts_row(db_pool):
+    svc = NicheService(db_pool)
+    niche = await svc.create(slug="glad-labs", name="Glad Labs",
+                             writer_rag_mode="TWO_PASS", batch_size=5)
+    assert isinstance(niche, Niche)
+    assert niche.slug == "glad-labs"
+    assert niche.writer_rag_mode == "TWO_PASS"
+    fetched = await svc.get_by_slug("glad-labs")
+    assert fetched.id == niche.id
+
+
+async def test_create_niche_rejects_duplicate_slug(db_pool):
+    svc = NicheService(db_pool)
+    await svc.create(slug="dupe", name="A")
+    with pytest.raises(Exception):
+        await svc.create(slug="dupe", name="B")
+
+
+async def test_set_goals_validates_weights_sum_to_100(db_pool):
+    svc = NicheService(db_pool)
+    n = await svc.create(slug="x", name="X")
+    with pytest.raises(ValueError, match="weights must sum to ~100"):
+        await svc.set_goals(n.id, [
+            NicheGoal(goal_type="TRAFFIC", weight_pct=30),
+            NicheGoal(goal_type="EDUCATION", weight_pct=20),
+            # sums to 50, should reject
+        ])
+    # 100 ± 1 tolerance is fine
+    await svc.set_goals(n.id, [
+        NicheGoal(goal_type="TRAFFIC", weight_pct=60),
+        NicheGoal(goal_type="EDUCATION", weight_pct=40),
+    ])
+    fetched = await svc.get_goals(n.id)
+    assert {g.goal_type: g.weight_pct for g in fetched} == {"TRAFFIC": 60, "EDUCATION": 40}
+
+
+async def test_set_sources_replaces_prior_config(db_pool):
+    svc = NicheService(db_pool)
+    n = await svc.create(slug="y", name="Y")
+    await svc.set_sources(n.id, [
+        NicheSource(source_name="hackernews", enabled=True, weight_pct=50),
+        NicheSource(source_name="devto", enabled=True, weight_pct=50),
+    ])
+    await svc.set_sources(n.id, [
+        NicheSource(source_name="internal_rag", enabled=True, weight_pct=100),
+    ])
+    fetched = await svc.get_sources(n.id)
+    assert len(fetched) == 1
+    assert fetched[0].source_name == "internal_rag"

--- a/src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
+++ b/src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
@@ -8,6 +8,8 @@ defined in ``tests/unit/conftest.py``. Skipped automatically when no live
 Postgres DSN is reachable.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from services.niche_service import NicheService, NicheGoal, NicheSource
@@ -195,3 +197,209 @@ async def test_only_one_open_batch_per_niche(db_pool, monkeypatch):
             n.id,
         )
     assert open_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Operator-interaction tests (Task 7)
+# ---------------------------------------------------------------------------
+#
+# These tests don't exercise run_sweep — they seed a batch + candidates
+# directly via SQL so each test isolates the operator method under
+# test (show / rank / edit / resolve / reject). The seed helper returns
+# (niche, batch_id, ext_ids, int_ids).
+
+
+async def _seed_batch_with_mixed_candidates(
+    db_pool, *, slug: str, n_external: int = 2, n_internal: int = 3,
+):
+    """Insert a niche + an open batch + N external + M internal candidates.
+
+    Returns (niche, batch_id, [external candidate ids], [internal candidate ids]).
+
+    Scores are assigned descending starting at 90 so an unranked
+    show_batch sort-by-effective-score is deterministic.
+    """
+    nsvc = NicheService(db_pool)
+    niche = await nsvc.create(slug=slug, name=slug.title(), batch_size=5)
+    await nsvc.set_goals(niche.id, [NicheGoal("TRAFFIC", 100)])
+    await nsvc.set_sources(
+        niche.id, [NicheSource("internal_rag", enabled=True, weight_pct=100)],
+    )
+
+    expires = datetime.now(timezone.utc) + timedelta(days=7)
+    ext_ids: list[str] = []
+    int_ids: list[str] = []
+    async with db_pool.acquire() as conn:
+        batch_row = await conn.fetchrow(
+            "INSERT INTO topic_batches (niche_id, status, expires_at) "
+            "VALUES ($1, 'open', $2) RETURNING id",
+            niche.id, expires,
+        )
+        batch_id = batch_row["id"]
+
+        rank = 0
+        # External candidates first.
+        for i in range(n_external):
+            rank += 1
+            row = await conn.fetchrow(
+                """
+                INSERT INTO topic_candidates
+                  (batch_id, niche_id, source_name, source_ref, title, summary,
+                   score, score_breakdown, rank_in_batch, decay_factor)
+                VALUES ($1, $2, 'external', $3, $4, $5, $6, '{}'::jsonb, $7, 1.0)
+                RETURNING id
+                """,
+                batch_id, niche.id, f"ext-ref-{i}",
+                f"External Topic {i}", f"External summary {i}",
+                90 - rank, rank,
+            )
+            ext_ids.append(str(row["id"]))
+
+        # Internal candidates next.
+        for i in range(n_internal):
+            rank += 1
+            row = await conn.fetchrow(
+                """
+                INSERT INTO internal_topic_candidates
+                  (batch_id, niche_id, source_kind, primary_ref,
+                   supporting_refs, distilled_topic, distilled_angle,
+                   score, score_breakdown, rank_in_batch, decay_factor)
+                VALUES ($1, $2, 'claude_session', $3, '[]'::jsonb, $4, $5,
+                        $6, '{}'::jsonb, $7, 1.0)
+                RETURNING id
+                """,
+                batch_id, niche.id, f"int-ref-{i}",
+                f"Internal Topic {i}", f"Internal angle {i}",
+                90 - rank, rank,
+            )
+            int_ids.append(str(row["id"]))
+
+    return niche, batch_id, ext_ids, int_ids
+
+
+async def test_show_batch_returns_unified_ranked_view(db_pool):
+    """show_batch merges external + internal candidates into a single
+    list ordered by effective_score (= score * decay_factor) desc."""
+    niche, batch_id, ext_ids, int_ids = await _seed_batch_with_mixed_candidates(
+        db_pool, slug="show-batch-niche", n_external=2, n_internal=3,
+    )
+
+    svc = TopicBatchService(db_pool)
+    view = await svc.show_batch(batch_id=batch_id)
+
+    assert view.id == batch_id
+    assert view.status == "open"
+    assert view.picked_candidate_id is None
+    assert len(view.candidates) == 5
+    # Mixed kinds present.
+    kinds = {c.kind for c in view.candidates}
+    assert kinds == {"external", "internal"}
+    # Sorted by effective_score desc.
+    scores = [c.effective_score for c in view.candidates]
+    assert scores == sorted(scores, reverse=True)
+    # Every candidate has an effective_score == score * decay_factor.
+    for c in view.candidates:
+        assert c.effective_score == pytest.approx(c.score * c.decay_factor)
+
+
+async def test_rank_batch_records_operator_order(db_pool):
+    """rank_batch should set operator_rank by 1-based position in the
+    provided list, transparently spanning both candidate tables."""
+    niche, batch_id, ext_ids, int_ids = await _seed_batch_with_mixed_candidates(
+        db_pool, slug="rank-batch-niche", n_external=2, n_internal=3,
+    )
+    # Interleave external + internal ids so the test exercises the
+    # external-first-then-internal fallback.
+    ordered = [int_ids[2], ext_ids[0], int_ids[0], ext_ids[1], int_ids[1]]
+
+    svc = TopicBatchService(db_pool)
+    await svc.rank_batch(batch_id=batch_id, ordered_candidate_ids=ordered)
+
+    view = await svc.show_batch(batch_id=batch_id)
+    ranked = sorted(
+        [c for c in view.candidates if c.operator_rank is not None],
+        key=lambda c: c.operator_rank,
+    )
+    assert [c.id for c in ranked] == ordered
+
+
+async def test_edit_winner_sets_operator_edit_fields(db_pool):
+    """edit_winner updates the operator_edited_topic / angle on the
+    rank-1 candidate, regardless of which table it lives in."""
+    niche, batch_id, ext_ids, int_ids = await _seed_batch_with_mixed_candidates(
+        db_pool, slug="edit-winner-niche", n_external=2, n_internal=3,
+    )
+    # Make an INTERNAL candidate the winner so we exercise the fallback.
+    ordered = [int_ids[0], ext_ids[0], int_ids[1], ext_ids[1], int_ids[2]]
+    svc = TopicBatchService(db_pool)
+    await svc.rank_batch(batch_id=batch_id, ordered_candidate_ids=ordered)
+
+    await svc.edit_winner(
+        batch_id=batch_id, topic="Operator-Edited Title", angle="Operator angle",
+    )
+
+    view = await svc.show_batch(batch_id=batch_id)
+    winner = next(c for c in view.candidates if c.operator_rank == 1)
+    assert winner.id == int_ids[0]
+    assert winner.operator_edited_topic == "Operator-Edited Title"
+    assert winner.operator_edited_angle == "Operator angle"
+
+
+async def test_resolve_batch_advances_winner_and_marks_resolved(db_pool, monkeypatch):
+    """resolve_batch hands the winner off to the pipeline + flips
+    status to resolved + records picked_candidate_id."""
+    niche, batch_id, ext_ids, int_ids = await _seed_batch_with_mixed_candidates(
+        db_pool, slug="resolve-batch-niche", n_external=2, n_internal=3,
+    )
+    ordered = [ext_ids[0], int_ids[0], ext_ids[1], int_ids[1], int_ids[2]]
+    svc = TopicBatchService(db_pool)
+    await svc.rank_batch(batch_id=batch_id, ordered_candidate_ids=ordered)
+
+    handoff_calls: list[tuple[str, str, str]] = []
+
+    async def fake_handoff(self, candidate, niche, handoff_batch_id):
+        # CRITICAL: signature carries batch_id explicitly so the
+        # content_tasks row's topic_batch_id provenance points at the
+        # batch, not the candidate. Plan body had the wrong variable
+        # threaded through; this fake captures it so the test asserts
+        # we wired the right value.
+        handoff_calls.append(
+            (candidate.id, niche.slug, str(handoff_batch_id)),
+        )
+
+    monkeypatch.setattr(
+        "services.topic_batch_service.TopicBatchService._handoff_to_pipeline",
+        fake_handoff,
+    )
+
+    await svc.resolve_batch(batch_id=batch_id)
+
+    view = await svc.show_batch(batch_id=batch_id)
+    assert view.status == "resolved"
+    assert view.picked_candidate_id is not None
+    assert str(view.picked_candidate_id) == ext_ids[0]
+    assert len(handoff_calls) == 1
+    assert handoff_calls[0] == (ext_ids[0], niche.slug, str(batch_id))
+
+
+async def test_reject_batch_marks_expired_and_can_re_discover(db_pool):
+    """reject_batch flips the batch to expired + frees up the
+    one-open-batch-per-niche slot for a future sweep."""
+    niche, batch_id, ext_ids, int_ids = await _seed_batch_with_mixed_candidates(
+        db_pool, slug="reject-batch-niche", n_external=2, n_internal=3,
+    )
+    svc = TopicBatchService(db_pool)
+    await svc.reject_batch(batch_id=batch_id, reason="none of these")
+
+    view = await svc.show_batch(batch_id=batch_id)
+    assert view.status == "expired"
+
+    # One-open-batch-per-niche slot freed: a new open batch row may now
+    # be inserted without violating uq_one_open_batch_per_niche.
+    async with db_pool.acquire() as conn:
+        new_batch_row = await conn.fetchrow(
+            "INSERT INTO topic_batches (niche_id, status, expires_at) "
+            "VALUES ($1, 'open', NOW() + INTERVAL '7 days') RETURNING id",
+            niche.id,
+        )
+    assert new_batch_row is not None

--- a/src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
+++ b/src/cofounder_agent/tests/unit/services/test_topic_batch_service.py
@@ -1,0 +1,197 @@
+"""Tests for TopicBatchService — orchestrates discovery → rank → batch → gate.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 6)
+
+Roundtrips against the real Postgres test DB via the ``db_pool`` fixture
+defined in ``tests/unit/conftest.py``. Skipped automatically when no live
+Postgres DSN is reachable.
+"""
+
+import pytest
+
+from services.niche_service import NicheService, NicheGoal, NicheSource
+from services.internal_rag_source import InternalCandidate
+from services.topic_batch_service import TopicBatchService
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture(autouse=True)
+def _clear_goal_vec_cache():
+    """``services.topic_ranking._GOAL_VEC_CACHE`` is module-level and lives
+    for the process lifetime. If we don't clear it between tests, the
+    second test inherits the first test's monkeypatched-fake vectors —
+    or worse, a real production vector that bled in from another module.
+    """
+    from services.topic_ranking import _GOAL_VEC_CACHE
+    _GOAL_VEC_CACHE.clear()
+    yield
+    _GOAL_VEC_CACHE.clear()
+
+
+async def test_run_sweep_creates_open_batch_with_candidates(db_pool, monkeypatch):
+    """End-to-end happy-path:
+
+    Seed a niche with batch_size=3 and a single ``internal_rag`` source,
+    monkeypatch the source to yield 5 fake candidates, monkeypatch the
+    embedding + LLM scorer, expect an ``open`` batch with 3 ranked
+    candidates persisted across the candidate tables.
+    """
+    nsvc = NicheService(db_pool)
+    n = await nsvc.create(slug="test-niche-batch-svc", name="Test", batch_size=3)
+    await nsvc.set_goals(n.id, [
+        NicheGoal("TRAFFIC", 50),
+        NicheGoal("EDUCATION", 50),
+    ])
+    await nsvc.set_sources(n.id, [
+        NicheSource("internal_rag", enabled=True, weight_pct=100),
+    ])
+
+    # Mock the internal source generator → 5 fake candidates.
+    async def fake_internal_generate(self, **kwargs):
+        return [
+            InternalCandidate(
+                source_kind="claude_session",
+                primary_ref=f"sess-{i}",
+                distilled_topic=f"Topic {i}",
+                distilled_angle=f"Angle {i}",
+            )
+            for i in range(5)
+        ]
+
+    monkeypatch.setattr(
+        "services.internal_rag_source.InternalRagSource.generate",
+        fake_internal_generate,
+    )
+
+    # Mock the embedding step + LLM final scorer. Patch BOTH the public
+    # ``embed_text`` (used for candidate texts via lazy import in
+    # TopicBatchService) AND the private ``_embed_text_cached`` (used by
+    # ``goal_vector_for`` to embed goal description anchors).
+    async def fake_embed_text(text):
+        return [0.1] * 768
+
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed_text)
+    monkeypatch.setattr(
+        "services.topic_ranking._embed_text_cached", fake_embed_text,
+    )
+
+    async def fake_llm_score(candidates, weights, *, model=None):
+        # Return the same candidates with a descending llm_score so order
+        # is deterministic. Use enumerate to mimic the spec: first → 80,
+        # then 75, 70, …
+        result = {}
+        for idx, c in enumerate(candidates):
+            c.llm_score = 80 - idx * 5
+            c.score_breakdown = {}
+            result[c.id] = c
+        return result
+
+    monkeypatch.setattr("services.topic_ranking.llm_final_score", fake_llm_score)
+
+    svc = TopicBatchService(db_pool)
+    batch = await svc.run_sweep(niche_id=n.id)
+
+    assert batch is not None
+    assert batch.status == "open"
+    # batch_size=3, 5 generated → top 3 in the batch.
+    assert batch.candidate_count == 3
+
+    # Verify rows actually landed in the DB.
+    async with db_pool.acquire() as conn:
+        external_count = await conn.fetchval(
+            "SELECT count(*) FROM topic_candidates WHERE batch_id = $1",
+            batch.id,
+        )
+        internal_count = await conn.fetchval(
+            "SELECT count(*) FROM internal_topic_candidates WHERE batch_id = $1",
+            batch.id,
+        )
+        run_row = await conn.fetchrow(
+            "SELECT * FROM discovery_runs WHERE niche_id = $1 ORDER BY started_at DESC LIMIT 1",
+            n.id,
+        )
+    assert external_count + internal_count == 3
+    # All five candidates came from the internal_rag source → all rows
+    # are internal_topic_candidates.
+    assert internal_count == 3
+    assert external_count == 0
+    # discovery_runs row recorded.
+    assert run_row is not None
+    assert run_row["batch_id"] == batch.id
+    assert run_row["finished_at"] is not None
+    assert run_row["candidates_generated"] == 5
+
+
+async def test_only_one_open_batch_per_niche(db_pool, monkeypatch):
+    """Second sweep while an open batch exists should be a no-op (return None).
+
+    The ``uq_one_open_batch_per_niche`` partial unique index also enforces
+    this at the DB level, but the service short-circuits before insert so
+    the operator gets a friendly skip rather than a constraint violation.
+    """
+    nsvc = NicheService(db_pool)
+    n = await nsvc.create(
+        slug="solo-batch", name="Solo",
+        batch_size=2,
+        # Force the floor check to always pass on the second call.
+        discovery_cadence_minute_floor=1,
+    )
+    await nsvc.set_goals(n.id, [
+        NicheGoal("TRAFFIC", 100),
+    ])
+    await nsvc.set_sources(n.id, [
+        NicheSource("internal_rag", enabled=True, weight_pct=100),
+    ])
+
+    async def fake_internal_generate(self, **kwargs):
+        return [
+            InternalCandidate(
+                source_kind="claude_session",
+                primary_ref=f"solo-{i}",
+                distilled_topic=f"T{i}",
+                distilled_angle=f"A{i}",
+            )
+            for i in range(3)
+        ]
+
+    monkeypatch.setattr(
+        "services.internal_rag_source.InternalRagSource.generate",
+        fake_internal_generate,
+    )
+
+    async def fake_embed_text(text):
+        return [0.1] * 768
+
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed_text)
+    monkeypatch.setattr(
+        "services.topic_ranking._embed_text_cached", fake_embed_text,
+    )
+
+    async def fake_llm_score(candidates, weights, *, model=None):
+        result = {}
+        for idx, c in enumerate(candidates):
+            c.llm_score = 50 - idx
+            c.score_breakdown = {}
+            result[c.id] = c
+        return result
+
+    monkeypatch.setattr("services.topic_ranking.llm_final_score", fake_llm_score)
+
+    svc = TopicBatchService(db_pool)
+    first = await svc.run_sweep(niche_id=n.id)
+    assert first is not None
+    assert first.status == "open"
+
+    # Second sweep — open batch already exists → service must return None
+    # rather than insert a second open batch.
+    second = await svc.run_sweep(niche_id=n.id)
+    assert second is None
+
+    async with db_pool.acquire() as conn:
+        open_count = await conn.fetchval(
+            "SELECT count(*) FROM topic_batches WHERE niche_id = $1 AND status = 'open'",
+            n.id,
+        )
+    assert open_count == 1

--- a/src/cofounder_agent/tests/unit/services/test_topic_ranking.py
+++ b/src/cofounder_agent/tests/unit/services/test_topic_ranking.py
@@ -45,3 +45,29 @@ async def test_weighted_cosine_score_combines_per_goal_signals():
     assert score == pytest.approx(0.6, abs=0.01)
     assert breakdown == {"TRAFFIC": pytest.approx(0.6, abs=0.01),
                          "EDUCATION": pytest.approx(0.0, abs=0.01)}
+
+
+async def test_llm_final_score_returns_score_per_candidate(monkeypatch):
+    from services.topic_ranking import llm_final_score, ScoredCandidate
+
+    async def fake_ollama_chat(prompt: str, *, model: str) -> str:
+        # Simulated JSON response from glm-4.7-5090
+        return '{"c1": {"score": 87.5, "breakdown": {"TRAFFIC": 0.5, "EDUCATION": 0.375}},'  \
+               ' "c2": {"score": 42.0, "breakdown": {"TRAFFIC": 0.2, "EDUCATION": 0.22}}}'
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_ollama_chat)
+
+    candidates = [
+        ScoredCandidate(id="c1", title="A", summary="x", embedding_score=0.6),
+        ScoredCandidate(id="c2", title="B", summary="y", embedding_score=0.4),
+    ]
+    weights = [NicheGoal("TRAFFIC", 60), NicheGoal("EDUCATION", 40)]
+    scored = await llm_final_score(candidates, weights)
+    assert scored["c1"].llm_score == 87.5
+    assert scored["c2"].llm_score == 42.0
+
+
+def test_apply_decay_multiplies_score():
+    from services.topic_ranking import apply_decay
+    assert apply_decay(score=80, decay_factor=1.0) == 80
+    assert apply_decay(score=80, decay_factor=0.7) == pytest.approx(56)
+    assert apply_decay(score=80, decay_factor=0.49) == pytest.approx(39.2)

--- a/src/cofounder_agent/tests/unit/services/test_topic_ranking.py
+++ b/src/cofounder_agent/tests/unit/services/test_topic_ranking.py
@@ -1,0 +1,47 @@
+"""Tests for topic_ranking — goal vectors + weighted cosine scoring.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 3)
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from services.topic_ranking import (
+    GOAL_DESCRIPTIONS, goal_vector_for, weighted_cosine_score,
+)
+from services.niche_service import NicheGoal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_all_goal_types_have_descriptions():
+    expected = {"TRAFFIC","EDUCATION","BRAND","AUTHORITY","REVENUE","COMMUNITY","NICHE_DEPTH"}
+    assert set(GOAL_DESCRIPTIONS.keys()) == expected
+    for desc in GOAL_DESCRIPTIONS.values():
+        assert isinstance(desc, str) and len(desc) > 20
+
+
+async def test_goal_vector_caches_embeddings(monkeypatch):
+    calls = []
+    async def fake_embed(text):
+        calls.append(text)
+        return [0.1] * 768
+    monkeypatch.setattr("services.topic_ranking._embed_text_cached", fake_embed)
+    v1 = await goal_vector_for("TRAFFIC")
+    v2 = await goal_vector_for("TRAFFIC")
+    assert v1 == v2
+    # _embed_text_cached itself caches, so calls should be 1
+    assert len(calls) == 1
+
+
+async def test_weighted_cosine_score_combines_per_goal_signals():
+    candidate_vec = [1.0, 0.0, 0.0]
+    # Two goals; one aligns perfectly with candidate, the other is orthogonal.
+    goal_vecs = {"TRAFFIC": [1.0, 0.0, 0.0], "EDUCATION": [0.0, 1.0, 0.0]}
+    weights = [NicheGoal("TRAFFIC", 60), NicheGoal("EDUCATION", 40)]
+    score, breakdown = weighted_cosine_score(candidate_vec, goal_vecs, weights)
+    # 0.6 * 1.0 (perfect TRAFFIC) + 0.4 * 0.0 (orthogonal EDUCATION) = 0.6
+    assert score == pytest.approx(0.6, abs=0.01)
+    assert breakdown == {"TRAFFIC": pytest.approx(0.6, abs=0.01),
+                         "EDUCATION": pytest.approx(0.0, abs=0.01)}

--- a/src/cofounder_agent/tests/unit/services/writer_rag_modes/test_modes.py
+++ b/src/cofounder_agent/tests/unit/services/writer_rag_modes/test_modes.py
@@ -1,0 +1,33 @@
+"""Tests for the writer_rag_mode dispatcher.
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 9)
+"""
+
+import pytest
+
+from services.writer_rag_modes import dispatch_writer_mode
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_dispatch_calls_topic_only_handler(monkeypatch):
+    called = {}
+
+    async def fake_handler(*, topic, angle, niche_id, pool, **kw):
+        called["mode"] = "TOPIC_ONLY"
+        return {"draft": "..."}
+
+    monkeypatch.setattr("services.writer_rag_modes.topic_only.run", fake_handler)
+    out = await dispatch_writer_mode(
+        mode="TOPIC_ONLY", topic="t", angle="a", niche_id="n", pool=None,
+    )
+    assert called["mode"] == "TOPIC_ONLY"
+    assert "draft" in out
+
+
+async def test_dispatch_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown writer_rag_mode"):
+        await dispatch_writer_mode(
+            mode="BOGUS", topic="t", angle="a", niche_id="n", pool=None,
+        )

--- a/src/cofounder_agent/tests/unit/services/writer_rag_modes/test_two_pass.py
+++ b/src/cofounder_agent/tests/unit/services/writer_rag_modes/test_two_pass.py
@@ -1,0 +1,103 @@
+"""Tests for the TWO_PASS writer mode (LangGraph state machine).
+
+Spec: docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md
+Plan: docs/superpowers/plans/2026-04-30-rag-pivot-niche-discovery.md (Task 13)
+
+Deviations from plan:
+- Monkeypatches `services.topic_ranking.embed_text` instead of
+  `services.embedding_service.embed_text` because embedding_service has
+  no module-level `embed_text` helper — that helper lives in topic_ranking.
+- Uses `raising=False` for the `generate_with_context` and `research_topic`
+  monkeypatches because neither symbol currently exists in production
+  (`ai_content_generator` and `research_service` modules). Production
+  wire-up of those callables is tracked separately (Task 14 wires the
+  writer; `research_topic` needs a follow-up to expose a module-level
+  helper around `ResearchService`).
+- The plan's `_fake_pool_with_no_snippets` helper used `AsyncMock()` for
+  the pool, which made `pool.acquire()` return a coroutine and broke the
+  `async with` protocol. Switched to `MagicMock` for the sync `acquire`
+  method that returns an async-context-manager mock, matching the
+  established pool-mocking pattern elsewhere in this codebase.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.writer_rag_modes import two_pass
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_pool_with_no_snippets():
+    """Fake asyncpg pool whose acquire() context manager yields a conn with
+    fetch() → []. Note: pool.acquire is a SYNC method that returns an
+    object supporting `async with`, so we use MagicMock for acquire (not
+    AsyncMock) to avoid the call returning a coroutine."""
+    pool = MagicMock()
+    conn_mock = AsyncMock()
+    conn_mock.fetch = AsyncMock(return_value=[])
+    acquire_ctx = AsyncMock()
+    acquire_ctx.__aenter__ = AsyncMock(return_value=conn_mock)
+    acquire_ctx.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=acquire_ctx)
+    return pool
+
+
+async def test_no_external_needed_returns_pass1_draft(monkeypatch):
+    """First draft has no [EXTERNAL_NEEDED] markers → graph short-circuits, no revise."""
+    async def fake_pass1(topic, angle, snippets, extra_instructions=None):
+        return "A clean first draft with no markers."
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", fake_pass1, raising=False)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert result["draft"] == "A clean first draft with no markers."
+    assert result["external_lookups"] == []
+    assert result["revision_loops"] == 0
+
+
+async def test_external_needed_triggers_research_and_revise(monkeypatch):
+    """One marker → research → revise → done in 1 loop."""
+    drafts = iter([
+        "First draft with [EXTERNAL_NEEDED: a fact] inside.",
+        "Revised draft with the actual fact inside.",
+    ])
+    async def fake_pass1(topic, angle, snippets, extra_instructions=None):
+        return next(drafts)
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", fake_pass1, raising=False)
+    async def fake_revise(prompt, *, model):
+        return next(drafts)
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_revise)
+    async def fake_research(query, max_sources=2):
+        return f"External research result for: {query}"
+    monkeypatch.setattr("services.research_service.research_topic", fake_research, raising=False)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert "Revised draft" in result["draft"]
+    assert len(result["external_lookups"]) == 1
+    assert result["revision_loops"] == 1
+
+
+async def test_loop_caps_at_max_revisions(monkeypatch):
+    """Pathological: every revision adds new markers. Loop must terminate at _MAX_REVISION_LOOPS=3."""
+    counter = {"n": 0}
+    async def always_needs_more(topic, angle, snippets, extra_instructions=None):
+        counter["n"] += 1
+        return f"Draft with [EXTERNAL_NEEDED: thing {counter['n']}] inside."
+    monkeypatch.setattr("services.ai_content_generator.generate_with_context", always_needs_more, raising=False)
+    async def fake_revise(prompt, *, model):
+        counter["n"] += 1
+        return f"Revised with [EXTERNAL_NEEDED: another thing {counter['n']}]."
+    monkeypatch.setattr("services.topic_ranking._ollama_chat_json", fake_revise)
+    async def fake_research(query, max_sources=2):
+        return "fact"
+    monkeypatch.setattr("services.research_service.research_topic", fake_research, raising=False)
+    async def fake_embed(text): return [0.0] * 768
+    monkeypatch.setattr("services.topic_ranking.embed_text", fake_embed)
+
+    result = await two_pass.run(topic="t", angle="a", niche_id="n", pool=_fake_pool_with_no_snippets())
+    assert result["revision_loops"] == 3
+    assert result["loop_capped"] is True


### PR DESCRIPTION
Implements [docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md](https://github.com/Glad-Labs/poindexter/blob/feat/niche-topic-discovery/docs/superpowers/specs/2026-04-30-rag-pivot-niche-discovery-design.md).

## Summary

Adds niche-as-config topic discovery with hybrid embed+LLM ranking, a batch-of-N operator interaction surface, and a per-niche `writer_rag_mode` that pivots the writer from "summarize external content" to "report from internal context." Glad Labs is seeded as the first niche using `TWO_PASS` mode. The system is deliberately general — future niches register via `INSERT INTO niches`.

## What's in the box

**Data model (3 migrations):**
- `0113` — 7 new tables: `niches`, `niche_goals`, `niche_sources`, `topic_batches`, `topic_candidates`, `internal_topic_candidates`, `discovery_runs` + `uq_one_open_batch_per_niche` partial unique index
- `0114` — extends `content_tasks` with `niche_slug`, `writer_rag_mode`, `topic_batch_id` (all nullable for backcompat)
- `0115` — seeds `glad-labs` niche with `TWO_PASS` mode, 5 weighted goals (sum 100), 5 weighted sources (internal_rag lead)

**Service layer:**
- `NicheService` — CRUD over niches/goals/sources, validates 7-literal goal types + 99-101 weight-sum tolerance
- `topic_ranking` — `GOAL_DESCRIPTIONS`, lazy-cached goal vectors, weighted cosine, `llm_final_score`, `apply_decay`
- `InternalRagSource` — pulls per-source-kind snippets from the embeddings table, distills `(topic, angle)` per snippet via LLM
- `TopicBatchService` — orchestrator: discover → carry-forward (decay 0.7) → embed pre-rank → top 10 → LLM final-score → top batch_size → write batch → log run. Plus operator interactions (show/rank/edit/resolve/reject) and `_handoff_to_pipeline` that creates a `content_tasks` row with full niche+mode+batch provenance.

**Writer modes (4):**
- `TOPIC_ONLY` — single embedding query, snippets in prompt
- `CITATION_BUDGET` — same but writer required to cite >= N internal sources
- `STORY_SPINE` — outline-first pass, then expand to prose
- `TWO_PASS` (Glad Labs default) — internal-first draft → detect `[EXTERNAL_NEEDED: ...]` markers → external research → revise → loop, capped at 3 revisions. Implemented as a **LangGraph state machine** (per spec §"OSS leverage decisions") because of the conditional re-entry; the simpler modes stay plain Python.
- Dispatched via `dispatch_writer_mode(...)` from `services/writer_rag_modes/__init__.py`. Wired into `services/stages/generate_content.py`: tasks with `writer_rag_mode` set use the new path; pre-niche tasks stay on the legacy generator.

**Operator surface:**
- `poindexter topics show-batch --niche glad-labs`
- `poindexter topics rank-batch <batch_id> --order id1,id2,...`
- `poindexter topics edit-winner <batch_id> [--topic ...] [--angle ...]`
- `poindexter topics resolve-batch <batch_id>` (advances to pipeline)
- `poindexter topics reject-batch <batch_id> [--reason ...]`
- `poindexter topics niche list / show <slug>`
- Same five `topics_*` tools exposed via MCP for the connector flow.

## Bugs the implementation surfaced (and fixed)

The plan was written against an assumed-existing `services.embedding_service.embed_text` + `services.research_service.research_topic` — neither existed. Fixed in flight:
- Public `services.topic_ranking.embed_text` helper that uses the existing `plugins.registry.get_llm_providers('ollama_native').embed(...)` pattern.
- `services.research_service.research_topic` shim wrapping `ResearchService.build_context` (with a stub-on-error fallback so the TWO_PASS revise loop never crashes from a network blip).
- `_handoff_to_pipeline` plan body had a typo passing `winner.id` as `topic_batch_id` (would FK-violate); corrected to the actual `batch_id`. Plus added `task_id`/`task_type`/`content_type` to the INSERT (NOT NULL, no defaults) — caught by the integration test.

## OSS leverage decisions (per spec §)

- **LangGraph** adopted for `TWO_PASS` only (added as dep). Other modes stay plain Python.
- **Langfuse** observability deferred — pre-flight reminder noted but explicit `@observe` wiring left for a follow-up sweep.
- **Ragas / DeepEval / LiteLLM** also deferred — they're already in-tree, get wired when there's a quality target to chase.

## Test plan

- [x] `migrations-smoke` CI verifies 0113/0114/0115 apply cleanly to a fresh `pgvector/pgvector:pg16` (currently 68/68 migrations).
- [x] All new unit tests pass: niche_service (4), topic_ranking (5), internal_rag_source (1), topic_batch_service (7), writer_rag_modes/test_modes (2), writer_rag_modes/test_two_pass (3) — 22 new tests, no regressions in the existing suite.
- [x] Integration `test_niche_discovery_e2e.py` passes — sweep produces a batch + resolve advances to a `content_tasks` row with full provenance.
- [ ] Manual smoke: `poindexter topics niche show glad-labs` → run sweep → show-batch → rank-batch → edit-winner → resolve-batch → confirm `content_tasks` row exists. Will run after merge against the live DB.

## Notes / out of scope

- `topic_proposal_service` deprecation step (Task 19) was a no-op — the file does not exist on `main` (only existed on a feature branch never merged).
- Pipeline-gateway operator-backpressure caps are explicitly out of scope per spec.
- Pyright surfaces a few `total=False` TypedDict warnings on `two_pass.py` — runtime safe (the graph populates state in order); cleanup in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)