### PR TITLE
chore: remove stale TODO in 0073 migration (closes #172)

### DIFF
--- a/src/cofounder_agent/services/migrations/0073_alert_rules_and_grafana_sync.py
+++ b/src/cofounder_agent/services/migrations/0073_alert_rules_and_grafana_sync.py
@@ -143,7 +143,7 @@ _SEED_SETTINGS = [
     ),
     (
         "grafana_api_token",
-        "",  # TODO: operator-provided (see description)
+        "",
         "monitoring",
         (
             "Grafana service-account token (Administration → Service "


### PR DESCRIPTION
Removes the redundant `# TODO: operator-provided (see description)` comment on the `grafana_api_token` row in migration 0073. The description text underneath already states the operator must set this via the admin UI — the TODO was a stale note from when the operator-setup pattern was still being designed.

Closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)