### PR TITLE
fix(publish): use tempfile.mkstemp for RSS feed regen (closes #284)

### DIFF
--- a/src/cofounder_agent/services/publish_service.py
+++ b/src/cofounder_agent/services/publish_service.py
@@ -15,6 +15,7 @@ import json
 import os
 import random
 import re
+import tempfile
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -819,16 +820,26 @@ async def publish_post_from_task(
                 from services.bootstrap_defaults import DEFAULT_WORKER_API_URL
                 from services.site_config import site_config as _scfg
                 _api_base = _scfg.get("internal_api_base_url", DEFAULT_WORKER_API_URL)
-                async with _hx.AsyncClient(timeout=_hx.Timeout(30.0, connect=5.0)) as _client:
-                    _feed = await _client.get(f"{_api_base}/api/podcast/feed.xml", timeout=30)
-                    _feed_path = "/tmp/podcast-feed.xml"
-                    # Blocking file I/O in async context — push to worker thread
-                    # so the event loop isn't stalled while we write the feed file.
-                    await asyncio.to_thread(
-                        _write_text_file, _feed_path, _feed.text,
-                    )
-                    await upload_to_r2(_feed_path, "podcast/feed.xml", "application/rss+xml")
-                    logger.info("[R2] Podcast RSS feed regenerated on CDN")
+                # Per-call temp file via tempfile.mkstemp avoids hardcoded
+                # /tmp paths (Bandit B108) and prevents collisions when
+                # multiple publishes run concurrently.
+                _fd, _feed_path = tempfile.mkstemp(suffix=".xml", prefix="poindexter-podcast-")
+                try:
+                    os.close(_fd)  # _write_text_file reopens the path
+                    async with _hx.AsyncClient(timeout=_hx.Timeout(30.0, connect=5.0)) as _client:
+                        _feed = await _client.get(f"{_api_base}/api/podcast/feed.xml", timeout=30)
+                        # Blocking file I/O in async context — push to worker thread
+                        # so the event loop isn't stalled while we write the feed file.
+                        await asyncio.to_thread(
+                            _write_text_file, _feed_path, _feed.text,
+                        )
+                        await upload_to_r2(_feed_path, "podcast/feed.xml", "application/rss+xml")
+                        logger.info("[R2] Podcast RSS feed regenerated on CDN")
+                finally:
+                    try:
+                        os.unlink(_feed_path)
+                    except OSError:
+                        pass
             except Exception as _e:
                 logger.warning("[R2] Podcast feed regen failed (non-fatal): %s", _e)
 
@@ -839,14 +850,23 @@ async def publish_post_from_task(
                 from services.bootstrap_defaults import DEFAULT_WORKER_API_URL
                 from services.site_config import site_config as _scfg
                 _api_base = _scfg.get("internal_api_base_url", DEFAULT_WORKER_API_URL)
-                async with _hx.AsyncClient(timeout=_hx.Timeout(30.0, connect=5.0)) as _client:
-                    _feed = await _client.get(f"{_api_base}/api/video/feed.xml", timeout=30)
-                    _feed_path = "/tmp/video-feed.xml"
-                    await asyncio.to_thread(
-                        _write_text_file, _feed_path, _feed.text,
-                    )
-                    await upload_to_r2(_feed_path, "video/feed.xml", "application/rss+xml")
-                    logger.info("[R2] Video RSS feed regenerated on CDN")
+                # Per-call temp file via tempfile.mkstemp avoids hardcoded
+                # /tmp paths (Bandit B108).
+                _fd, _feed_path = tempfile.mkstemp(suffix=".xml", prefix="poindexter-video-")
+                try:
+                    os.close(_fd)
+                    async with _hx.AsyncClient(timeout=_hx.Timeout(30.0, connect=5.0)) as _client:
+                        _feed = await _client.get(f"{_api_base}/api/video/feed.xml", timeout=30)
+                        await asyncio.to_thread(
+                            _write_text_file, _feed_path, _feed.text,
+                        )
+                        await upload_to_r2(_feed_path, "video/feed.xml", "application/rss+xml")
+                        logger.info("[R2] Video RSS feed regenerated on CDN")
+                finally:
+                    try:
+                        os.unlink(_feed_path)
+                    except OSError:
+                        pass
             except Exception as _e:
                 logger.warning("[R2] Video feed regen failed (non-fatal): %s", _e)
 


### PR DESCRIPTION
Replaces the two hardcoded /tmp paths in publish_service.py RSS feed regen with per-call tempfile.mkstemp calls + finally-block unlink. Resolves Bandit B108. No behavior change beyond the path source.

## Before / After (Bandit B108 on `services/publish_service.py`)
- Before: 2 findings (lines 824, 844 — `/tmp/podcast-feed.xml`, `/tmp/video-feed.xml`)
- After: 0 findings

## Tests
`tests/unit/services/test_publish_service.py` — 31 passed, 0 failed. No tests mocked the old `/tmp/` paths, so no test changes were needed.