### PR TITLE
fix(tests): two test-suite bugs from 2026-04-27 audit (closes #170, #171)

### DIFF
--- a/src/cofounder_agent/tests/unit/services/test_telemetry.py
+++ b/src/cofounder_agent/tests/unit/services/test_telemetry.py
@@ -113,7 +113,16 @@ class TestModuleConstants:
         assert isinstance(telemetry_mod.OPENTELEMETRY_AVAILABLE, bool)
 
     def test_openai_instrumentor_is_none_or_class(self):
-        oi = getattr(telemetry_mod, "OpenAIInstrumentor", None)
+        """Guard against silent removal/rename of OpenAIInstrumentor.
+
+        telemetry.py always assigns ``OpenAIInstrumentor`` at module
+        import time (either the imported class or ``None``). Use direct
+        attribute access (not ``getattr(..., None)``) so a future
+        opentelemetry-instrumentation-openai upgrade that drops or
+        renames the symbol fails this test loudly instead of passing
+        silently (closes #171).
+        """
+        oi = telemetry_mod.OpenAIInstrumentor
         # Either None (if not installed) or a class
         assert oi is None or callable(oi)
 

--- a/src/cofounder_agent/tests/unit/services/test_web_research.py
+++ b/src/cofounder_agent/tests/unit/services/test_web_research.py
@@ -33,12 +33,23 @@ class TestSearchSimple:
 
 class TestDDGSearch:
     async def test_handles_import_error(self):
+        """Both DDG client modules unavailable -> empty list, no network call.
+
+        Production code tries `ddgs` first then falls back to
+        `duckduckgo_search`. Patch BOTH to None so the test can never
+        accidentally hit the real DuckDuckGo network in any environment
+        where one of them is installed (closes #170).
+        """
         researcher = WebResearcher()
-        with patch.dict("sys.modules", {"duckduckgo_search": None}):
-            # Should fail gracefully
+        with patch.dict(
+            "sys.modules",
+            {"ddgs": None, "duckduckgo_search": None},
+        ):
+            # Should fail gracefully — both imports raise ImportError
             results = await researcher._ddg_search("test", 3)
-            # May return empty or raise — just shouldn't crash
+            # Caller wraps in try/except and returns []
             assert isinstance(results, list)
+            assert results == []
 
 
 class TestExtractContent:


### PR DESCRIPTION
## Summary

Addresses 2 of the 3 test-suite bugs surfaced by the 2026-04-27 pre-existing-issue audit.

### #170 — `test_handles_import_error` could leak to real DuckDuckGo network
`services/web_research.py` tries `ddgs` first then falls back to `duckduckgo_search`. The test in `tests/unit/services/test_web_research.py::TestDDGSearch::test_handles_import_error` only patched `duckduckgo_search` to `None`, so on environments where `ddgs` is installed the test would silently make a real DDG network call (and rely on the production exception handler to swallow any flakiness). Now patches BOTH modules to `None` and asserts an empty list, so the test exercises only the import-error path and never touches the network.

### #171 — `test_openai_instrumentor_is_none_or_class` masked regression with getattr default
`tests/unit/services/test_telemetry.py::TestModuleConstants::test_openai_instrumentor_is_none_or_class` used `getattr(module, "OpenAIInstrumentor", None)` so a missing module attribute would silently pass. Replaced with direct attribute access (`telemetry_mod.OpenAIInstrumentor`) — telemetry.py always assigns the symbol at import time (either the imported class or `None`), so direct access is safe today, and a future `opentelemetry-instrumentation-openai` upgrade that drops/renames the symbol will now fail this test loudly. Added a docstring explaining why this assertion exists.

### #168 — NOT fixed in this PR (file does not exist on `main`)
`src/cofounder_agent/tests/unit/plugins/test_anthropic_provider.py` is not present on `Glad-Labs/poindexter:main`. Both the `AnthropicProvider` class and its tests live on private/feature branches that have not been merged to public main yet. The order-dependent test cannot be patched here. Re-file or fold into the AnthropicProvider merge PR when that ships.

## Test plan

- [x] `cd src/cofounder_agent && poetry run pytest tests/unit/services/test_web_research.py -v --no-cov` — 18 passed
- [x] `cd src/cofounder_agent && poetry run pytest tests/unit/services/test_telemetry.py -v --no-cov` — 20 passed
- [x] `cd src/cofounder_agent && poetry run pytest tests/unit/services/test_telemetry.py tests/unit/services/test_web_research.py --no-cov` — 38 passed combined

Branch cut fresh from `github/main` per workflow rules.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>