### PR TITLE
feat(brain): per-probe child spans (closes #176)

### DIFF
--- a/brain/health_probes.py
+++ b/brain/health_probes.py
@@ -17,6 +17,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
+from typing import Any
 
 try:
     # When brain/ is on sys.path directly (container runtime), import bare.
@@ -27,6 +28,37 @@ except ImportError:
     from brain.docker_utils import localize_url, resolve_url
 
 logger = logging.getLogger("brain.probes")
+
+# OpenTelemetry is optional — health probes work with or without it.
+# When the opentelemetry SDK isn't installed, ``_tracer`` is a no-op
+# implementation that matches the real API's ``start_as_current_span``
+# contract. Same shape as src/cofounder_agent/services/llm_providers/dispatcher.py
+# so behavior stays uniform across the codebase.
+try:
+    from opentelemetry import trace as _otel_trace  # type: ignore[import-untyped]
+
+    _tracer = _otel_trace.get_tracer("poindexter.brain.probes")
+except ImportError:  # pragma: no cover - exercised in minimal dev envs
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _noop_span(_name: str, **_kwargs: Any):
+        class _NoopSpan:
+            def set_attribute(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def record_exception(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            def set_status(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+        yield _NoopSpan()
+
+    class _NoopTracer:
+        start_as_current_span = staticmethod(_noop_span)
+
+    _tracer = _NoopTracer()
 
 # Bootstrap defaults — overridden from app_settings on first probe run.
 # localize_url rewrites `localhost` to `host.docker.internal` when running
@@ -1066,10 +1098,25 @@ async def run_health_probes(pool, notify_fn=None):
             continue
 
         _mark_run(name)
-        try:
-            result = await probe_fn(pool)
-        except Exception as e:
-            result = {"ok": False, "detail": f"probe crashed: {e}"}
+        # Per-probe child span — gives Tempo a flame-graph entry per probe so
+        # slow/failing probes are visible instead of aggregating under the
+        # parent run_health_probes span (issue #176).
+        with _tracer.start_as_current_span(
+            f"brain.probe.{name}",
+            attributes={"probe.name": name},
+        ) as span:
+            start = time.monotonic()
+            try:
+                try:
+                    result = await probe_fn(pool)
+                except Exception as e:
+                    result = {"ok": False, "detail": f"probe crashed: {e}"}
+                    span.record_exception(e)
+                span.set_attribute("probe.ok", bool(result.get("ok", False)))
+            finally:
+                span.set_attribute(
+                    "probe.duration_s", time.monotonic() - start,
+                )
 
         results[name] = result
         ok = result.get("ok", False)

--- a/src/cofounder_agent/tests/unit/services/test_brain_health_probes.py
+++ b/src/cofounder_agent/tests/unit/services/test_brain_health_probes.py
@@ -212,6 +212,107 @@ class TestRunHealthProbes:
         p.execute.assert_not_called()
 
 
+@pytest.fixture
+def in_memory_otel_exporter():
+    """Install an InMemorySpanExporter as the global OTel provider for
+    the test, then restore. Module-scoped state is hard here because
+    OTel refuses to override an already-set TracerProvider — so we
+    install once, share, and clear spans between tests."""
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    # Re-use an already-installed provider if there is one (subsequent
+    # tests in the same process). Otherwise install ours.
+    current = trace.get_tracer_provider()
+    if isinstance(current, TracerProvider):
+        provider = current
+    else:
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    exporter.clear()
+    yield exporter
+    exporter.clear()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPerProbeSpans:
+    """Issue #176 — each probe in run_health_probes gets its own
+    brain.probe.<name> child span carrying probe.name, probe.duration_s,
+    and probe.ok attributes. Verified via the OTel SDK
+    InMemorySpanExporter so we don't need a live Tempo backend."""
+
+    async def test_each_probe_emits_child_span_with_attributes(
+        self, in_memory_otel_exporter,
+    ):
+        # Two fake probes — one passes, one fails — registered into
+        # the PROBES dict so run_health_probes iterates them. Skip
+        # _is_due / db writes / Telegram alerts to keep the assertion
+        # surface tight.
+        async def ok_probe(_pool):
+            return {"ok": True, "detail": "all good"}
+
+        async def fail_probe(_pool):
+            return {"ok": False, "detail": "boom"}
+
+        with patch.dict(
+            hp.PROBES,
+            {"fake_ok": ok_probe, "fake_fail": fail_probe},
+            clear=True,
+        ), \
+            patch.object(hp, "_is_due", return_value=True), \
+            patch.object(hp, "_create_gitea_issue"):
+            hp._config_synced = True
+            p = _make_pool()
+            await hp.run_health_probes(p, notify_fn=None)
+
+        spans = {s.name: s for s in in_memory_otel_exporter.get_finished_spans()}
+        assert "brain.probe.fake_ok" in spans
+        assert "brain.probe.fake_fail" in spans
+
+        ok_span = spans["brain.probe.fake_ok"]
+        assert ok_span.attributes["probe.name"] == "fake_ok"
+        assert ok_span.attributes["probe.ok"] is True
+        assert "probe.duration_s" in ok_span.attributes
+        assert ok_span.attributes["probe.duration_s"] >= 0
+
+        fail_span = spans["brain.probe.fake_fail"]
+        assert fail_span.attributes["probe.name"] == "fake_fail"
+        assert fail_span.attributes["probe.ok"] is False
+        assert "probe.duration_s" in fail_span.attributes
+
+    async def test_probe_exception_still_closes_span_with_ok_false(
+        self, in_memory_otel_exporter,
+    ):
+        """try/finally must end the span even when the probe raises —
+        and the span should record probe.ok=false (since the result
+        dict gets stamped {ok: False, detail: 'probe crashed: ...'})."""
+        async def crashy_probe(_pool):
+            raise RuntimeError("kaboom")
+
+        with patch.dict(
+            hp.PROBES, {"crashy": crashy_probe}, clear=True,
+        ), \
+            patch.object(hp, "_is_due", return_value=True), \
+            patch.object(hp, "_create_gitea_issue"):
+            hp._config_synced = True
+            p = _make_pool()
+            await hp.run_health_probes(p, notify_fn=None)
+
+        spans = {s.name: s for s in in_memory_otel_exporter.get_finished_spans()}
+        assert "brain.probe.crashy" in spans
+        crashy_span = spans["brain.probe.crashy"]
+        assert crashy_span.attributes["probe.name"] == "crashy"
+        assert crashy_span.attributes["probe.ok"] is False
+        assert "probe.duration_s" in crashy_span.attributes
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestProbeTopicQuality:


### PR DESCRIPTION
Each health probe inside `brain.health_probes.run_health_probes` now runs in its own `brain.probe.<name>` child span carrying `probe.name`, `probe.duration_s`, and `probe.ok` attributes. Slow or failing probes are now visible as discrete entries in the Tempo flame graph instead of aggregating under the parent run loop, and operators can filter the span view by `probe.ok=false` to surface failing probes individually.

The OTel import follows the same try/import-or-noop pattern as `src/cofounder_agent/services/llm_providers/dispatcher.py` so the brain still boots in dev environments without the SDK installed. Span termination is wrapped in try/finally — exceptions inside a probe still close the span cleanly with `probe.ok=false`.

Closes #176.

## Acceptance checklist

- [x] Each probe inside `run_health_probes` gets its own child span (`brain.probe.<name>`)
- [x] Span carries `probe.name`, `probe.duration_s`, `probe.ok` attributes
- [x] Span ends cleanly even on probe exception (try/finally + `probe.ok=false`)
- [x] Verified via two new `InMemorySpanExporter`-backed unit tests (Tempo verification deferred to staging — can't reach Tempo from CI)

## Test plan

- [x] `pytest src/cofounder_agent/tests/unit/services/test_brain_health_probes.py` — 28 passed (26 existing + 2 new)
- [ ] After merge: confirm `brain.probe.*` spans appear in Tempo and that `probe.ok=false` filter surfaces failing probes individually