### PR TITLE
chore(deps): Windows-host audit of native-extension deps (closes #224)

### DIFF
--- a/src/cofounder_agent/poetry.lock
+++ b/src/cofounder_agent/poetry.lock
@@ -562,7 +562,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" or extra == \"profiling\""
+markers = "platform_python_implementation != \"PyPy\" or sys_platform != \"win32\" and extra == \"profiling\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -3964,7 +3964,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "implementation_name != \"PyPy\" and (platform_python_implementation != \"PyPy\" or extra == \"profiling\")"
+markers = "implementation_name != \"PyPy\" and (platform_python_implementation != \"PyPy\" or sys_platform != \"win32\") and (platform_python_implementation != \"PyPy\" or extra == \"profiling\")"
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -4255,7 +4255,7 @@ description = "Pyroscope Python integration"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"profiling\""
+markers = "sys_platform != \"win32\" and extra == \"profiling\""
 files = [
     {file = "pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8"},
     {file = "pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:dc98355e27c0b7b61f27066500fe1045b70e9459bb8b9a3082bc4755cb6392b6"},
@@ -6716,4 +6716,4 @@ profiling = ["pyroscope-io"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "916c9bc077b2dacafd7509b266cb6bdc229994a922373a198d108ca1ec3b06a3"
+content-hash = "fd4dee9318b0d6aa164f1724fbe8ebbe412d5f8a4f03895aab7c3fe056f6fcdc"

--- a/src/cofounder_agent/pyproject.toml
+++ b/src/cofounder_agent/pyproject.toml
@@ -85,7 +85,10 @@ apscheduler = "^3.11.2"
 prometheus-client = "^0.25.0"
 # Continuous profiling — LGTM+P stack (GH #75). Opt-in via app_settings
 # enable_pyroscope; services/profiling.py configures the agent.
-pyroscope-io = { version = "^0.8.5", optional = true }
+# sys_platform marker: pyroscope-io ships no Windows wheels (closes #224)
+# — required for Matt's Windows host `poetry install --extras profiling`
+# to skip cleanly instead of falling through to a Rust source build.
+pyroscope-io = { version = "^0.8.5", optional = true, markers = "sys_platform != 'win32'" }
 langgraph = ">=0.2,<1.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
## Summary

Audit of every Python dep in `src/cofounder_agent/pyproject.toml` for Windows + Python 3.12 wheel availability, per #224.

## Audit method

For each direct dep in `[tool.poetry.dependencies]` and the noteworthy transitive native deps from `poetry.lock`, ran:

```bash
pip download --no-deps --platform win_amd64 --python-version 3.12 \
    --only-binary=:all: --dest /tmp/wheel_check <pkg>==<version>
```

Any package that fails this command requires a source build, which is what bit Matt's `poetry install` on 2026-04-29 (no Rust toolchain on the Windows host).

Total deps in `pyproject.toml`: 38 direct (33 main + 5 ml/profiling extras). All inspected. ~25 transitive native deps from the lockfile spot-checked.

## Findings

| Dep | Has cp312-win_amd64 wheel? | Action |
|---|---|---|
| **pyroscope-io 0.8.16** | NO (only macOS + manylinux) | Add `markers = "sys_platform != 'win32'"` |
| uvloop 0.22.1 (via `uvicorn[standard]`) | NO | Already marked upstream — no action |
| All other direct deps (cryptography, pillow, asyncpg, lxml, playwright, torch, transformers, diffusers, mcp, langgraph, boto3, cloudinary, edge-tts, pyasn1, apscheduler, prometheus-client, sentry-sdk, structlog, pyjwt, ddgs, beautifulsoup4, resend, slowapi, fastapi, uvicorn, pydantic, pydantic-settings, aiohttp, httpx, python-dotenv, python-multipart, aiofiles, markdown, python-slugify, starlette, email-validator, python-json-logger, setuptools) | YES | None |
| Transitive native deps spot-checked: cffi 2.0.0, pydantic-core 2.46.3, rpds-py 0.30.0, frozenlist, multidict, yarl, propcache, xxhash, orjson, ormsgpack, uuid-utils, regex 2025.11.3, primp 1.2.2, hf-xet 1.4.3, lxml 6.1.0, watchfiles, httptools, websockets, greenlet, wrapt, lazy-object-proxy, tokenizers 0.22.2, safetensors 0.6.2, zstandard, MarkupSafe, pywin32 | YES | None |

## Changes

- `src/cofounder_agent/pyproject.toml`: scope `pyroscope-io` with `markers = "sys_platform != 'win32'"` (additive — already `optional = true` and gated by `extra == "profiling"`).
- `src/cofounder_agent/poetry.lock`: regenerated.

The lockfile entry now reads `markers = "sys_platform != \"win32\" and extra == \"profiling\""`. Linux worker container still installs `pyroscope-io` when invoked with `--extras profiling`; Windows host skips it.

## Verification

```bash
$ poetry install --dry-run --extras profiling
# pyroscope-io no longer in install plan on Windows
```

## Ambiguous cases

None. Either the dep ships Windows wheels or (in pyroscope-io's case) it's only used by `services/profiling.py`, which is a Linux-container observability piece that already gracefully handles `ImportError`.

## Note on CI smoke test

Issue #224 has a fourth acceptance item — adding a Windows GitHub Actions runner that does `poetry install` from scratch as a regression guard. Out of scope for this PR (kept narrow per the audit-then-mark contract); recommend a follow-up issue if desired.

## Test plan

- [x] `poetry lock` succeeds and produces minimal diff
- [x] `poetry install --dry-run` on Windows succeeds
- [x] `poetry install --dry-run --extras profiling` on Windows skips pyroscope-io (verified via grep)
- [ ] Linux container CI build still installs everything (rely on existing Woodpecker / GH Actions)