### PR TITLE
feat(config): migrate 5 env-vars to app_settings (closes #175)

### DIFF
--- a/src/cofounder_agent/agents/content_agent/config.py
+++ b/src/cofounder_agent/agents/content_agent/config.py
@@ -32,6 +32,7 @@ del _fix_sys_path, _PathType
 import os
 
 from services.logger_config import get_logger
+from services.site_config import site_config
 
 # --- Define Base Directory ---
 # Ensures that all file paths are relative to the project root, making the application more portable.
@@ -95,7 +96,18 @@ class Config:
 
         # --- External Services & APIs ---
         self.PEXELS_API_KEY = os.getenv("PEXELS_API_KEY")  # For sourcing stock photos
-        self.SERPER_API_KEY = os.getenv("SERPER_API_KEY")  # For real-time web search capabilities
+        # SERPER_API_KEY: DB-first via site_config (GH-175). Marked is_secret=true
+        # in the migration, but read SYNCHRONOUSLY here for back-compat with
+        # callers that don't `await`. site_config.get() consults its in-memory
+        # cache first (populated from app_settings at startup) and falls back
+        # to env var. A future migration can switch to `await
+        # site_config.get_secret("serper_api_key")` once the read site is
+        # async-friendly — the schema is already in place for that.
+        self.SERPER_API_KEY = (
+            site_config.get("serper_api_key", "")
+            or os.getenv("SERPER_API_KEY", "")
+            or None
+        )
 
         # --- Local Image Generation & Storage ---
         self.IMAGE_STORAGE_PATH = os.path.join(self.BASE_DIR, "content-agent", "generated_images")
@@ -111,15 +123,27 @@ class Config:
         # --- Local LLM (Ollama) Configuration ---
         # #198: no hardcoded localhost default. An empty string means
         # "Ollama not configured" and callers must handle that explicitly.
-        self.LOCAL_LLM_API_URL = os.getenv("LOCAL_LLM_API_URL", "")
-        self.LOCAL_LLM_MODEL_NAME = os.getenv("LOCAL_LLM_MODEL_NAME", "auto")
+        # GH-175: DB-first via site_config; env-var still wins as fallback
+        # because site_config.get() consults env when the key is absent
+        # from the in-memory cache.
+        self.LOCAL_LLM_API_URL = (
+            site_config.get("local_llm_api_url", "")
+            or os.getenv("LOCAL_LLM_API_URL", "")
+        )
+        self.LOCAL_LLM_MODEL_NAME = (
+            site_config.get("local_llm_model_name", "auto")
+            or os.getenv("LOCAL_LLM_MODEL_NAME", "auto")
+        )
 
         # --- Logging Configuration ---
         self.LOG_DIR = os.path.join(self.BASE_DIR, "content-agent", "logs")
         self.APP_LOG_FILE = os.path.join(self.LOG_DIR, "app.log")
         self.PROMPTS_LOG_FILE = os.path.join(self.LOG_DIR, "prompts.log")
-        self.MAX_LOG_SIZE_MB = int(os.getenv("MAX_LOG_SIZE_MB", "5"))
-        self.MAX_LOG_BACKUP_COUNT = int(os.getenv("MAX_LOG_BACKUP_COUNT", "3"))
+        # GH-175: DB-first via site_config.get_int; env still wins as
+        # fallback because site_config.get_int delegates to get() which
+        # consults env when the key is absent from the in-memory cache.
+        self.MAX_LOG_SIZE_MB = site_config.get_int("max_log_size_mb", 5)
+        self.MAX_LOG_BACKUP_COUNT = site_config.get_int("max_log_backup_count", 3)
 
 
 # --- Singleton Instance ---

--- a/src/cofounder_agent/services/migrations/0116_seed_content_agent_app_settings.py
+++ b/src/cofounder_agent/services/migrations/0116_seed_content_agent_app_settings.py
@@ -1,0 +1,158 @@
+"""Migration 0116: seed 5 content-agent env-vars into app_settings (GH-175).
+
+GH-175 — DB-first configuration migration. Five settings still read by
+``agents/content_agent/config.py`` via ``os.getenv`` are moved into
+``app_settings`` so operators can tune them at runtime without restarting
+the worker or editing docker-compose.
+
+Seeded keys (snake_case, mirroring the existing app_settings convention):
+
+* ``serper_api_key`` — Serper search API key. ``is_secret=true`` so it's
+  decrypted via ``site_config.get_secret(...)`` rather than cached in the
+  in-memory config dict. Note: at the time of writing,
+  ``agents/content_agent/config.py`` reads this synchronously at import
+  time and so still uses the env fallback path inside ``site_config.get``.
+  The schema is set up correctly here so a future migration to async
+  access is a code-only change.
+* ``local_llm_api_url`` — Ollama URL fallback. Empty default → "Ollama
+  not configured", per the no-silent-defaults rule. Operators set this
+  via ``poindexter settings set local_llm_api_url <url>`` or env.
+* ``local_llm_model_name`` — Ollama model fallback. Default ``"auto"``
+  matches the existing env-var fallback (OllamaClient picks the first
+  available pulled model).
+* ``max_log_size_mb`` — Log rotation file size cap (MB). Default ``5``
+  matches the existing hardcoded fallback.
+* ``max_log_backup_count`` — Log rotation backup count. Default ``3``
+  matches the existing hardcoded fallback.
+
+Each row reads the existing env-var at migration-apply time as its seed
+value so that operators who already have these vars exported don't lose
+their tuned values when the row is created. After this migration runs,
+the env-var path becomes a backward-compat fallback inside
+``site_config.get`` rather than the primary source.
+
+Idempotent — ``INSERT ... ON CONFLICT DO NOTHING`` leaves any
+operator-set value alone.
+"""
+
+import os
+
+from services.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _table_exists(conn, table: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+            "WHERE table_name = $1)",
+            table,
+        )
+    )
+
+
+def _seed_settings() -> list[tuple[str, str, str, str, bool]]:
+    """Build the seed rows. Reads env at apply-time so existing operator
+    values are preserved on first install rather than being clobbered by
+    a hardcoded default.
+
+    Returns list of (key, value, category, description, is_secret) tuples.
+    """
+    return [
+        (
+            "serper_api_key",
+            os.getenv("SERPER_API_KEY", ""),
+            "external_apis",
+            (
+                "Serper search API key for real-time web-search capability "
+                "in the content agent. Empty value disables web search "
+                "without crashing. Get a key from https://serper.dev. "
+                "Marked is_secret=true so it lives encrypted in the DB and "
+                "is fetched via site_config.get_secret(...). Ref: GH-175."
+            ),
+            True,
+        ),
+        (
+            "local_llm_api_url",
+            os.getenv("LOCAL_LLM_API_URL", ""),
+            "content",
+            (
+                "Ollama API base URL for local LLM calls (e.g. "
+                "http://localhost:11434). Empty value means 'Ollama not "
+                "configured' — callers must handle that explicitly per "
+                "the no-silent-defaults rule. Ref: GH-175."
+            ),
+            False,
+        ),
+        (
+            "local_llm_model_name",
+            os.getenv("LOCAL_LLM_MODEL_NAME", "auto"),
+            "content",
+            (
+                "Ollama model fallback used by agents/content_agent/config "
+                "when no per-task model is configured. 'auto' lets "
+                "OllamaClient pick the first available pulled model. "
+                "Override with a specific tag (e.g. 'gemma3:27b'). "
+                "Ref: GH-175."
+            ),
+            False,
+        ),
+        (
+            "max_log_size_mb",
+            os.getenv("MAX_LOG_SIZE_MB", "5"),
+            "logging",
+            (
+                "Maximum size in MB of a rotating log file before it's "
+                "rolled over. Default 5 MB matches the historical env-var "
+                "fallback. Ref: GH-175."
+            ),
+            False,
+        ),
+        (
+            "max_log_backup_count",
+            os.getenv("MAX_LOG_BACKUP_COUNT", "3"),
+            "logging",
+            (
+                "Number of rotated log backups to retain. Default 3 "
+                "matches the historical env-var fallback. Ref: GH-175."
+            ),
+            False,
+        ),
+    ]
+
+
+async def up(pool) -> None:
+    async with pool.acquire() as conn:
+        if not await _table_exists(conn, "app_settings"):
+            logger.info(
+                "Table 'app_settings' missing — skipping migration 0116"
+            )
+            return
+
+        rows = _seed_settings()
+        for key, value, category, description, is_secret in rows:
+            await conn.execute(
+                """
+                INSERT INTO app_settings (key, value, category, description, is_secret)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (key) DO NOTHING
+                """,
+                key, value, category, description, is_secret,
+            )
+        logger.info(
+            "Migration 0116: seeded %d content-agent settings (GH-175)",
+            len(rows),
+        )
+
+
+async def down(pool) -> None:
+    async with pool.acquire() as conn:
+        if not await _table_exists(conn, "app_settings"):
+            return
+        keys = [k for k, *_ in _seed_settings()]
+        await conn.execute(
+            "DELETE FROM app_settings WHERE key = ANY($1::text[])",
+            keys,
+        )
+        logger.info("Migration 0116 rolled back: removed %d settings", len(keys))


### PR DESCRIPTION
## Summary

Migrates the last five env-vars read by `agents/content_agent/config.py` into `app_settings` per the DB-first config principle. `Config()` now reads `site_config.get(...)` first and falls back to `os.getenv` for backward compatibility — operators with existing exported env-vars don't lose their values, and new operators can tune everything from the DB without restarting the worker.

- `serper_api_key` (already existed in `app_settings` since #058 with `is_secret=true`; this migration is a no-op for that key thanks to `ON CONFLICT DO NOTHING`)
- `local_llm_api_url` (new — empty default per no-silent-defaults)
- `local_llm_model_name` (new — `auto`)
- `max_log_size_mb` (new — `5`)
- `max_log_backup_count` (new — `3`)

`SERPER_API_KEY` stays a sync read (`site_config.get` + env fallback) for back-compat with the synchronous `Config()` callers. The `is_secret=true` schema is in place so a future migration can flip to `await site_config.get_secret(...)` without another DB change.

Closes #175.

## Test plan

- [x] `python scripts/ci/migrations_smoke.py` — 69 migrations apply cleanly on a fresh `pgvector/pgvector:pg16` container
- [x] `cd src/cofounder_agent && poetry run pytest tests/unit/agents/test_content_agent_config.py -v` — 11/11 pass
- [x] Verified seeded rows in `app_settings` (`local_llm_api_url`, `local_llm_model_name`, `max_log_size_mb`, `max_log_backup_count`) post-migration