### PR TITLE
fix(observability): add pyroscope-io to voice-agent Dockerfile (closes Glad-Labs/poindexter#418)

### DIFF
--- a/scripts/Dockerfile.voice-agent
+++ b/scripts/Dockerfile.voice-agent
@@ -49,7 +49,19 @@ RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir \
         "uvicorn[standard]" \
         livekit \
         livekit-api \
-        cryptography
+        cryptography \
+        "pyroscope-io>=0.8.5"
+
+# Fail-fast verification — confirm the pyroscope-io wheel actually
+# landed in the image. services/voice_agent_livekit.py and
+# services/voice_agent_webrtc.py both call services.profiling.setup_pyroscope()
+# at startup (wired in PR #297 / Glad-Labs/poindexter#406); without
+# the wheel the import silently fails and the voice agents never
+# show up in Pyroscope under the `poindexter-voice-livekit` /
+# `poindexter-voice-webrtc` service names. Asserting on ``configure``
+# mirrors brain/Dockerfile and src/cofounder_agent/Dockerfile.worker.
+# Closes Glad-Labs/poindexter#418.
+RUN python -c "import pyroscope; assert hasattr(pyroscope, 'configure'), 'pyroscope wheel missing configure()'; print('[BUILD] pyroscope-io OK — configure available')"
 
 # Pre-create the cache directory the model loaders write into. Bind-mounted
 # to a host volume in compose so first-boot model downloads (Silero ~2 MB,


### PR DESCRIPTION
## Summary

- PR #297 (closes #406) wired `setup_pyroscope()` into `services/voice_agent_livekit.py` and `services/voice_agent_webrtc.py`, but the voice-agent image uses raw `pip install` (not poetry), so the `pyroscope-io` wheel was never pulled in. `import pyroscope` silently failed at runtime and the voice agents never showed up in Pyroscope under the `poindexter-voice-livekit` / `poindexter-voice-webrtc` service names.
- Single-file change: append `"pyroscope-io>=0.8.5"` to the existing pip install block in `scripts/Dockerfile.voice-agent` and add the same fail-fast `import pyroscope; hasattr(..., 'configure')` verification step used in `brain/Dockerfile` and `src/cofounder_agent/Dockerfile.worker`. A silently-dropped wheel will now break the image build instead of the dashboard.
- Closes #418. No Python source changes — `voice_agent_livekit.py` / `voice_agent_webrtc.py` already call `setup_pyroscope()`; they just needed the wheel.

## Build verification

`docker build -f scripts/Dockerfile.voice-agent -t poindexter-voice-agent:test-418 .` succeeded locally:
- `Successfully installed ... pyroscope-io-1.0.6 ...`
- New verification step printed `[BUILD] pyroscope-io OK — configure available`
- `docker run --rm --entrypoint python poindexter-voice-agent:test-418 -c "import pyroscope; print(hasattr(pyroscope, 'configure'))"` printed `True`

## Test plan

- [x] Local image build succeeds and the new fail-fast `RUN python -c "import pyroscope ..."` step passes
- [x] Final image confirms `pyroscope.configure` is importable
- [ ] CI green on the public mirror
- [ ] After merge + rebuild on the host: both `poindexter-voice-agent-livekit` and `poindexter-voice-agent-webrtc` appear in Pyroscope under `poindexter-voice-livekit` / `poindexter-voice-webrtc` service names (per `setup_pyroscope()` config from PR #297)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>